### PR TITLE
Add task planner plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Plugins that enhance your productivity and workflow.
 - **[Simple Task](https://github.com/sethyuan/orca-simple-task)** - A plugin that helps you quickly create tasks using Orca Note's tag system. [@sethyuan](https://github.com/sethyuan)
 - **[Snippets](https://github.com/SaXz2/orca-snippets-plugin)** - JS and CSS code snippets management plugin. [@SaXz2](https://github.com/SaXz2)
 - **[Task Confetti](https://github.com/sethyuan/task-confetti)** - Celebrates task completion with confetti. [@sethyuan](https://github.com/sethyuan)
+- **[Task Planner](https://github.com/litcu/orca-plugin-task-planner)** - Advanced task planning plugin with dependencies, priority scoring, recurring tasks, review cycles, and custom views. [@litcu](https://github.com/litcu)
 - **[Today](https://github.com/SaXz2/orca-today-plugins)** - Automatically pins notes with the Today tag to the top of the current day's journal reference list. [@SaXz2](https://github.com/SaXz2)
 
 #### Note Management

--- a/README_CN.md
+++ b/README_CN.md
@@ -39,6 +39,7 @@
 - **[Simple Task](https://github.com/sethyuan/orca-simple-task)** - 帮助你使用 Orca Note 的标签系统快速创建任务的插件。 [@sethyuan](https://github.com/sethyuan)
 - **[Snippets](https://github.com/SaXz2/orca-snippets-plugin)** - JS 和 CSS 代码片段管理插件。 [@SaXz2](https://github.com/SaXz2)
 - **[Task Confetti](https://github.com/sethyuan/task-confetti)** - 任务完成时播放五彩纸屑特效。 [@sethyuan](https://github.com/sethyuan)
+- **[Task Planner](https://github.com/litcu/orca-plugin-task-planner)** - 高级任务规划插件，支持依赖关系、优先级评分、重复任务、回顾周期与自定义视图。 [@litcu](https://github.com/litcu)
 - **[Today](https://github.com/SaXz2/orca-today-plugins)** - 添加 Today 标签的笔记会自动置顶到当天日记的引用列表。 [@SaXz2](https://github.com/SaXz2)
 - **[恐龙工具箱](https://github.com/hqweay/orca-hqweay-go)** - 提供：中文排版一键格式化；行内样式清理；VoiceNotes 同步；CSV、Markdown 导入…… [@hqweay](https://github.com/hqweay)
 


### PR DESCRIPTION
## 变更说明
  在 `Productivity` 分类下新增 `Task Planner` 插件条目，并同步更新：

  - README.md
  - README_CN.md

  ## 插件地址
  - https://github.com/litcu/orca-plugin-task-planner

  ## 收录理由
  `Task Planner` 是 Orca Note 的任务规划插件，支持依赖关系、优先级评分、重复任务、回顾周期与自定义视图，可覆盖任务规划到执行回顾的完整流程。

  ## 自查
  - 条目格式符合 CONTRIBUTING.md 要求
  - 已按字母顺序插入分类列表
  - 中英文列表均已更新
  - 链接可访问