### PR TITLE
Update Tana Tag Color plugin to v1.2.7

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -215,10 +215,10 @@
     "description": "Applies Tana-style colors and icons to tagged blocks in Orca Note, with block-level color overrides and real-time updates.",
     "category": "Visualization",
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\" width=\"100\" height=\"100\"><circle cx=\"50\" cy=\"50\" r=\"45\" fill=\"#f8f9fa\" stroke=\"#dee2e6\" stroke-width=\"2\"/><g transform=\"translate(50, 50)\"><path d=\"M -20 -15 L 15 -15 L 20 0 L 15 15 L -20 15 Z\" fill=\"#6366f1\" stroke=\"#4f46e5\" stroke-width=\"2\"/><circle cx=\"-12\" cy=\"0\" r=\"3\" fill=\"#f8f9fa\"/><circle cx=\"5\" cy=\"-5\" r=\"4\" fill=\"#f59e0b\" opacity=\"0.9\"/><circle cx=\"8\" cy=\"3\" r=\"4\" fill=\"#10b981\" opacity=\"0.9\"/><circle cx=\"2\" cy=\"8\" r=\"4\" fill=\"#ef4444\" opacity=\"0.9\"/></g><defs><radialGradient id=\"shine\" cx=\"30%\" cy=\"30%\"><stop offset=\"0%\" style=\"stop-color:#ffffff;stop-opacity:0.3\"/><stop offset=\"100%\" style=\"stop-color:#ffffff;stop-opacity:0\"/></radialGradient></defs><circle cx=\"50\" cy=\"50\" r=\"45\" fill=\"url(#shine)\" pointer-events=\"none\"/></svg>",
-    "version": "1.2.6",
-    "updated": "2026-06-08T00:00:00Z",
+    "version": "1.2.7",
+    "updated": "2026-06-21T00:00:00Z",
     "home": "https://github.com/SaXz2/orca-tana-tag-color-plugin",
-    "zip": "https://github.com/SaXz2/orca-tana-tag-color-plugin/releases/download/v1.2.6/orca-tana-tag-color-plugin-v1.2.6.zip",
+    "zip": "https://github.com/SaXz2/orca-tana-tag-color-plugin/releases/download/v1.2.7/orca-tana-tag-color-plugin-v1.2.7.zip",
     "translations": {
       "zh": {
         "name": "Tana 标签颜色",


### PR DESCRIPTION
## Summary

更新 `SaXz2/tana-tag-color` 插件至 **v1.2.7**。

## Changes

- **v1.2.6 → v1.2.7**: 修复插件删除 Tana 原生句柄图标的问题
  - `applyIconToElement` 在无自定义图标时不再删除 `ti`/`ti-*` 类和 `data-icon` 属性
  - 只在没有 Tana 原生图标时才移除 `orca-block-handle-colored` 类
  - 修复单行、折叠、展开三种状态下句柄图标不显示的问题

## Test Plan

- [x] 单行无序列表句柄图标正常显示
- [x] 折叠状态句柄图标正常显示  
- [x] 展开状态句柄图标正常显示
- [x] 多标签句柄图标正常显示
- [x] 版本号和 zip 链接已验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)