### PR TITLE
Update orca-import-export to v2.4.7

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -25,10 +25,10 @@
     "description": "A multi-format import/export plugin for note migration with highlight syntax conversion support",
     "category": "Productivity",
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" width=\"64\" height=\"64\"><rect width=\"64\" height=\"64\" rx=\"14\" fill=\"#3370ff\"/><path d=\"M20 28l12-12 12 12\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><path d=\"M32 16v24\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\"/><path d=\"M20 36l12 12 12-12\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><path d=\"M32 48V24\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\"/></svg>",
-    "version": "2.4.6",
-    "updated": "2026-07-08T16:57:45Z",
+    "version": "2.4.7",
+    "updated": "2026-07-14T15:04:00Z",
     "home": "https://github.com/Peng52050/orca-import-export",
-    "zip": "https://github.com/Peng52050/orca-import-export/releases/download/v2.4.6/orca-import-export_v2.4.6.zip",
+    "zip": "https://github.com/Peng52050/orca-import-export/releases/download/v2.4.7/orca-import-export_v2.4.7.zip",
     "translations": {
       "zh": {
         "name": "Orca 导入导出",


### PR DESCRIPTION
## 更新内容

将 orca-import-export 插件版本从 v2.4.6 更新至 v2.4.7。

### v2.4.7 变更
- 版本号显示方式优化：从设置面板顶部徽章改为插件名旁边蓝色胶囊
- 修复 findPanel 严苛要求导致的错误

### 链接
- 项目主页: https://github.com/Peng52050/orca-import-export
- Release: https://github.com/Peng52050/orca-import-export/releases/tag/v2.4.7
- 下载链接: https://github.com/Peng52050/orca-import-export/releases/download/v2.4.7/orca-import-export_v2.4.7.zip