### PR TITLE
Add PicGo image bed plugin v0.9.7

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -38,6 +38,25 @@
     }
   },
   {
+    "author": "Peng52050",
+    "id": "orca-plugin-picgo",
+    "name": "PicGo Image Bed",
+    "description": "Upload images to 11+ image hosting services with clipboard, file picker, drag-and-drop, batch local upload, PicGo App integration, and AWS S3 support.",
+    "category": "Productivity",
+    "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\"><defs><linearGradient id=\"g\" x1=\"0\" y1=\"0\" x2=\"1\" y2=\"1\"><stop offset=\"0%\" stop-color=\"#2563eb\"/><stop offset=\"100%\" stop-color=\"#7c3aed\"/></linearGradient></defs><rect width=\"64\" height=\"64\" rx=\"14\" fill=\"url(#g)\"/><ellipse cx=\"32\" cy=\"46\" rx=\"18\" ry=\"9\" fill=\"#cbd5e1\"/><ellipse cx=\"22\" cy=\"44\" rx=\"8\" ry=\"6\" fill=\"#f1f5f9\"/><ellipse cx=\"42\" cy=\"44\" rx=\"8\" ry=\"6\" fill=\"#f1f5f9\"/><path d=\"M20 38c4-10 14-12 18-8 2 2 2 6 0 10-2 2-6 2-10 0-4-2-8 0-8-2z\" fill=\"#0f172a\"/><ellipse cx=\"34\" cy=\"30\" rx=\"3\" ry=\"1.5\" fill=\"#fff\"/><circle cx=\"36\" cy=\"29\" r=\".7\" fill=\"#0f172a\"/></svg>",
+    "version": "0.9.7",
+    "updated": "2026-07-14T15:25:00Z",
+    "home": "https://github.com/Peng52050/orca-plugin-picgo",
+    "zip": "https://github.com/Peng52050/orca-plugin-picgo/releases/download/v0.9.7/orca-plugin-picgo-v0.9.7.zip",
+    "translations": {
+      "zh": {
+        "name": "PicGo 图床插件",
+        "description": "支持上传图片到 11+ 图床服务，提供剪贴板上传、文件选择、拖拽上传、一键批量上传本地图片、PicGo App 委托上传及 AWS S3 支持。",
+        "category": "效率工具"
+      }
+    }
+  },
+  {
     "author": "cordinGH",
     "id": "dockpanel",
     "name": "Dockpanel",

--- a/plugins.json
+++ b/plugins.json
@@ -25,10 +25,10 @@
     "description": "A multi-format import/export plugin for note migration with highlight syntax conversion support",
     "category": "Productivity",
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" width=\"64\" height=\"64\"><rect width=\"64\" height=\"64\" rx=\"14\" fill=\"#3370ff\"/><path d=\"M20 28l12-12 12 12\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><path d=\"M32 16v24\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\"/><path d=\"M20 36l12 12 12-12\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><path d=\"M32 48V24\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\"/></svg>",
-    "version": "2.4.6",
-    "updated": "2026-07-08T16:57:45Z",
+    "version": "2.4.7",
+    "updated": "2026-07-14T15:04:00Z",
     "home": "https://github.com/Peng52050/orca-import-export",
-    "zip": "https://github.com/Peng52050/orca-import-export/releases/download/v2.4.6/orca-import-export_v2.4.6.zip",
+    "zip": "https://github.com/Peng52050/orca-import-export/releases/download/v2.4.7/orca-import-export_v2.4.7.zip",
     "translations": {
       "zh": {
         "name": "Orca 导入导出",


### PR DESCRIPTION
## New Plugin: PicGo Image Bed

### Plugin Information

| Field | Value |
|-------|-------|
| Author | Peng52050 |
| ID | orca-plugin-picgo |
| Version | 0.9.7 |
| Category | Productivity |
| License | MIT |

### Description

PicGo image bed plugin for Orca Note - upload images to 11+ image hosting services with clipboard, file picker, drag-and-drop, batch local upload, PicGo App integration, and AWS S3 support.

### Features

- **11+ image hosting services**: Sm.ms, Imgur, GitHub, GitLab, Aliyun OSS, Tencent COS, Upyun, Qiniu, Lsky Pro, AWS S3 (compatible with MinIO/Cloudflare R2), Custom API
- **Multiple upload methods**: clipboard upload, file picker, drag-and-drop, batch local image upload, PicGo/PicList App delegation
- **Auto insert**: supports Orca Note native image block, Markdown, HTML, and plain URL formats
- **Paste auto-upload**: automatically detects pasted images and uploads them
- **Bilingual support**: Chinese and English UI

### Links

- **Home**: https://github.com/Peng52050/orca-plugin-picgo
- **Download**: https://github.com/Peng52050/orca-plugin-picgo/releases/download/v0.9.7/orca-plugin-picgo-v0.9.7.zip

### Checklist

- [x] Plugin zip contains `package.json` with `version` field
- [x] Plugin zip contains `dist/` folder with build files
- [x] Plugin zip contains `LICENSE` file (MIT)
- [x] Plugin zip contains `icon.png`
- [x] Entry inserted in alphabetical order (by author, then by id)
- [x] Icon SVG provided (under 80x80 pixels)
- [x] All links tested and working