### PR TITLE
feat: add Orca SRS plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -152,6 +152,25 @@
     }
   },
   {
+    "author": "Samuelxiaozhuofeng",
+    "id": "orca-srs",
+    "name": "Orca SRS",
+    "description": "A spaced repetition and incremental reading plugin for Orca Note with FSRS scheduling, multiple card types, AI card generation, EPUB/web import, and reading workflows.",
+    "category": "Productivity",
+    "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAA40lEQVR4nO3awRHDMAhEUXfgY3pIBWnefeWYVGAvSLBI7Axn+b/Rzeg4X++l56AXCMAuEIBdIAC7oDrgc31XAvxzkSkHALsjJKMAd/oshh8wJX2c4QRMr3cbPICgep/BDAitdxhsgIR6q8EASKs3GVBAcj1ugACUetDQAECsRwy7A+j1jwYBKgPo3YhBAAEE2BVALwYN+96AAAIIsD6gjuGmUIDigAqG+7wGAK7hsa0HgGVAwtr8nU424EnNNjQJBmtMyy1lkMGX0XhTP4Ux/mm9VgFIoefrxRZ7BGCPAOxZHvADvnxNjjg5nvMAAAAASUVORK5CYII=",
+    "version": "1.0.0",
+    "updated": "2026-07-19T04:10:38Z",
+    "home": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin",
+    "zip": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.0/orca-srs-1.0.0.zip",
+    "translations": {
+      "zh": {
+        "name": "虎鲸标记",
+        "description": "为虎鲸笔记提供 FSRS 间隔重复、渐进阅读、多种卡片、AI 制卡以及 EPUB/网页导入的一体化学习插件。",
+        "category": "效率工具"
+      }
+    }
+  },
+  {
     "author": "SaXz2",
     "id": "bullet-theme",
     "name": "Bullet Theme",


### PR DESCRIPTION
## Summary

- Add Orca SRS 1.0.0 to the plugin registry
- Include the 64x64 PNG icon generated with the repository script
- Link to the published GitHub Release ZIP

## Verification

- Home and release asset links are live
- ZIP contains package.json, dist/, LICENSE, and icon.png
- plugins.json parses successfully and the entry follows author/id ordering