### PR TITLE
feat: update Orca SRS to 1.0.5

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -158,10 +158,10 @@
     "description": "A spaced repetition and incremental reading plugin for Orca Note with FSRS scheduling, multiple card types, AI card generation, EPUB/web import, and reading workflows.",
     "category": "Productivity",
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAA40lEQVR4nO3awRHDMAhEUXfgY3pIBWnefeWYVGAvSLBI7Axn+b/Rzeg4X++l56AXCMAuEIBdIAC7oDrgc31XAvxzkSkHALsjJKMAd/oshh8wJX2c4QRMr3cbPICgep/BDAitdxhsgIR6q8EASKs3GVBAcj1ugACUetDQAECsRwy7A+j1jwYBKgPo3YhBAAEE2BVALwYN+96AAAIIsD6gjuGmUIDigAqG+7wGAK7hsa0HgGVAwtr8nU424EnNNjQJBmtMyy1lkMGX0XhTP4Ux/mm9VgFIoefrxRZ7BGCPAOxZHvADvnxNjjg5nvMAAAAASUVORK5CYII=",
-    "version": "1.0.4",
-    "updated": "2026-07-22T04:19:48Z",
+    "version": "1.0.5",
+    "updated": "2026-07-24T23:51:36Z",
     "home": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin",
-    "zip": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.4/orca-srs-1.0.4.zip",
+    "zip": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.5/orca-srs-1.0.5.zip",
     "translations": {
       "zh": {
         "name": "虎鲸标记",


### PR DESCRIPTION
## Summary

- Update the existing `orca-srs` registry entry from `1.0.4` to `1.0.5`
- Point `zip` at the published GitHub Release asset for v1.0.5
- Refresh `updated` to the release publish timestamp

## Verification

- Release: https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/tag/v1.0.5
- ZIP: https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.5/orca-srs-1.0.5.zip
- ZIP contains top-level `orca-srs/` with `package.json` (`version: 1.0.5`), `dist/`, `LICENSE`, and `icon.png`
- `plugins.json` parses successfully; only version/zip/updated fields changed for `id: orca-srs`