### PR TITLE
feat: update Orca SRS to 1.0.8

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -158,10 +158,10 @@
     "description": "A spaced repetition and incremental reading plugin for Orca Note with FSRS scheduling, multiple card types, AI card generation, EPUB/web import, and reading workflows.",
     "category": "Productivity",
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAA40lEQVR4nO3awRHDMAhEUXfgY3pIBWnefeWYVGAvSLBI7Axn+b/Rzeg4X++l56AXCMAuEIBdIAC7oDrgc31XAvxzkSkHALsjJKMAd/oshh8wJX2c4QRMr3cbPICgep/BDAitdxhsgIR6q8EASKs3GVBAcj1ugACUetDQAECsRwy7A+j1jwYBKgPo3YhBAAEE2BVALwYN+96AAAIIsD6gjuGmUIDigAqG+7wGAK7hsa0HgGVAwtr8nU424EnNNjQJBmtMyy1lkMGX0XhTP4Ux/mm9VgFIoefrxRZ7BGCPAOxZHvADvnxNjjg5nvMAAAAASUVORK5CYII=",
-    "version": "1.0.7",
-    "updated": "2026-07-29T14:51:39Z",
+    "version": "1.0.8",
+    "updated": "2026-08-01T15:21:51Z",
     "home": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin",
-    "zip": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.7/orca-srs-1.0.7.zip",
+    "zip": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.8/orca-srs-1.0.8.zip",
     "translations": {
       "zh": {
         "name": "虎鲸标记",


### PR DESCRIPTION
## Orca SRS 1.0.8

更新 orca-srs 插件条目至 **1.0.8**：

- `version`: 1.0.7 → 1.0.8
- `zip`: 指向 `v1.0.8` release 的 `orca-srs-1.0.8.zip`
- `updated`: 2026-08-01

### 1.0.8 变更亮点
- 渐进阅读章末小测：制卡校验、自动打开制卡面板、题目原文一键定位、动态进度条
- 摘录教练（Extract Coach）：结合上下文的摘录处理建议
- AI 服务设置分段标签页；Gemini `google_search` 嵌套 grounding 工具、web search 按模型自动路由
- IR 间隔分散改为仅影响 due，配合优先级窗口

> 关联发布：https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/tag/v1.0.8