### PR TITLE
Add Orca Pinner to the plugins list

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -38,6 +38,25 @@
     }
   },
   {
+    "author": "luckyoubest2",
+    "id": "pinner",
+    "name": "Orca Pinner",
+    "description": "Pins reference previews and panels as draggable, always-visible floating windows, and opens the AI assistant in a fixed pinned window.",
+    "category": "Visualization",
+    "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAfMSURBVHhe7ZxLbBvFH8cRby6UCyCgRVw48Ch/iNdJBYICSZvd2Ycdp1ERCNLSJN7x2k7StHCgrZM0pAX+/MvjzyEpatp6H7bjtCkISsuBe0q5IF6CA1AKUoOK1BYJemDQb40de9Z2nG5FHHu+0k+Wd+Y34/1oZ2Y9j98VVzAxMTExMdWKpOiUV8RGjxydOoGwkTP4LmhGF6TTPnWv1Z17bkIh83VBs5JyJE3kyCRReg8RJZpnvYfs65COQmYCadZ/+Uj8RrqsulOrarQizfq4fetHxNc3DXAIwmBGETPtdF/fEQL5xVDiOPjTZdaNBGxs9vUfsZ8uJ6z5DfzAH4X0frrsmhfC1hZf7zSRtIQDzEIM/H19h4momgN0HTWpjo7UVUJQfwFuWtKSDiCXYlAOlIfU+FYon66zprQWv7NC1BJECqccIPJNiU7ZfV3W4DudpwBiOEWgXPG5/XfQddaMFM28XQwnj8FoSgPImG43Sf/m94mAjU8F1ZiaM/0kXAdIkM/pa9gjtBROftSimbfTddeEEDZFGD3pG8/Ck+EpU43z/r4jnfQrCnz39R7egFTjgp2vBMTA1qNEUC0h37cmtHp17GqE9beLj7i63USVaPoswvoTtG+++J54sxxJ/5Zp0k6ISu8UPL1v1mRfyAcPnpWKNF8pnAQ7w/dMNNM+xdSKD7RI4ckz4EeXBd2DENR/pX2WvERsdMjRqfOZPqzwpv2bj/yFQsYo7VNOIjZ2235UWVC+HJ06J2hGO+2zpIWwvrdtywcOeHIkRURsneYjyZtpn3Jaox68RcTGL1LEOZpDPUJIH6N9lrSQqr/h3/ye42btEVk1fojFyJW0TzlBH4dU/VSxLgHqEbDxP9pnSWsegD/ykQ+vo33KaXXnxPUC1n9iABnAysQAuhQD6FIMoEsxgC41H0AAks3b4Bte6fUPv9vUNnrCIw+egE9OGdoL17N5Vq17/QYGMAfQPAV57lv70gqvf+T/nDJ4sal9N2kK7Jqz9t2EU4b+hPSV/AvLIb+g6qcZQAAQsr56pCN2J+cbPvnw+j3E6xsmnDLoMLgO6Zx/+MSj63euELH5Td0DlDSLCKp+1qsMfdcUGHVAK2ZNbaME8iPV+E3ULEeZdQUQADRvGCeNbSOEU2J5oGLE699pN1/4LEiTY3b+5o3jtj9dZh0BNImAdbKqfRdpkLYXPGWNbS8Tjzx4zqPEZjzy4Hn4np8O+cEP/Oll0LoBCNP3zRvGiEfaUQDH6x8mXv/IGa8Sewx8Pb7Y4962kVm4np8P/Jo3jjlW9uoeIIy4D0k7ns33b5B3dGZGYgawIoANaEjM9+ekIZkBXABAjxTz5/tzcizAADKAly4G0KUYQJdiAF2KAXQpBtClGECXYgBdigF0KQbQpRhAl2IAXWqhABvQdmo2ZjubjVkIQI+47bl8/wZ52wYGsEKAMPPc6H95FmaiwbdB2f5EY9vIr2xGmgI435oIpwyeh4V1ToldKLomsq7O10TAYFWtZeM4W5WbT6UAQvOz14V9Q99WvC4cGCWQH6n62aJ7rgfgnIm+i/4NS1qlAGZ3JnC+nSs4ZfjTSnYmeH07Zxrbdi8vtTMBTi1JWvI71DXxIP07lqzKAvxnbwzseWn0j7zFKYN/wojr3Bsz+Aek/0fst49zldobg1TdPjsnR9I/CN16bkPSklZ5gIW7szgxdj/sxmoK7JqBhXX49PqGxrzy8H3ZPOV2Z2VMJwqc4tSSP88H8cmn3riVvlZ1mg/g5dwfWACxN/MkrinRnEXVaA1sOfolr8ZX0WlVpcUBmIFoH62NTP7IB+P3Zv19nRM3Kb2Hnhew/nv7ix/DQBYvrKHKtHgA5yCK4eRphA/c09GRuhaFzE8CW47+c/rTIP7+9wgfjL9E11M1WlyAcxARNr5AqnHMDhWQTVN1G6AUTv4iBo276bqqQv8qQFW3y7XLLjjRqRMpPEkd3oZ+copI4fQZKZzaL28yq3NA+TcBytE0fB4XsPE5xGUodizWttzrzuT3opq4n66jqjQPwMt7Vm7gfYCzrTVo3SWFkz9lmq4Ton3QMZz4mt+09wG6/KpT+dOaiUs8rWmWPK3JY2Mc8sHIK4WTpxSISUM1ZxusZn6+0LoXRXwwvk6OpkueF17of1ekxl8pfV44fQ5hK5DL2zXxILwLwjthBmKuj7yIQtaznp6xawpLr1KVO7EuhlOzYveBFtqnmITgwTVyeHK25Il1VZ+lfaCZilriZ4AI/5XlaPqioOpP0/mqVna8GGy8WS5mAsRC4EPxssf+RWy0yNHyMRMQNvYUi5kgdO9bKUXTpwGigK31dHrVq6KoHdi4oPRPb2zpSS3L9+3oSS3L/nNwE7WjtWvfo7wa76SvLwlB3BiI65J5P3PePECBPgziwyBsnESqfjhnWP+skrgxopY42todv42uu2bEd40vh1nkyiIXTeessshFFml5vkaD7mSVeX+Lb4WppssZOwvKE0L6QLG+ryYlhMyByxm9DULp0XXUvFBQ7/f1T7uLH9g3DfB66bLrRnz3/rViyDqeiWAJwRTLRLCEtMIIlsfgnZAus+7U0jO2TAyZr6GQZWVnUewYqpTNzbCYlqglXuWfYTFUHVK0SQ6i9cqR9AxSjZzJkckZhPVNimZytA8TExMT0+Lob5JsfSe4uIf4AAAAAElFTkSuQmCC",
+    "version": "1.0.0",
+    "updated": "2026-08-01T17:43:26Z",
+    "home": "https://github.com/luckyoubest2/Orca-pinner",
+    "zip": "https://github.com/luckyoubest2/Orca-pinner/releases/download/v1.0.0/orca-pinner-v1.0.0.zip",
+    "translations": {
+      "zh": {
+        "name": "Orca Pinner",
+        "description": "将引用预览与面板钉成可拖拽、常驻的浮动窗口，并让 AI 助手在固定的钉住窗口中打开。",
+        "category": "可视化"
+      }
+    }
+  },
+  {
     "author": "Peng52050",
     "id": "orca-import-export",
     "name": "Orca Import Export",


### PR DESCRIPTION
## English

This PR adds **Orca Pinner** to the plugin list.

**Orca Pinner** pins reference previews and panels as draggable, always-visible floating windows (rendered by Orca itself, fully live and interactive), and opens the AI assistant in a fixed pinned window. It supports middle-click / Shift+click pinning, draggable and resizable windows, per-panel window stacking, configurable control-button offsets, and hover-auto-hiding window controls.

- Home: https://github.com/luckyoubest2/Orca-pinner
- Release zip: https://github.com/luckyoubest2/Orca-pinner/releases/download/v1.0.2/orca-pinner-v1.0.2.zip

Checklist:
- [x] Icon resized to 80x80 (base64 PNG, generated with `scripts/png-to-base64.js`)
- [x] Links tested (home / zip)
- [x] Zip contains `package.json` (with version), `dist/`, `icon.png` and `LICENSE` (MIT)

## 中文

本 PR 将 **Orca Pinner** 收录到插件列表。

**Orca Pinner** 可以把引用预览与面板钉成可拖拽、常驻的浮动窗口（由 Orca 原生渲染，实时可交互），并让 AI 助手在固定的钉住窗口中打开。支持中键 / Shift+点击钉住、窗口拖动缩放、每面板多窗口堆叠、控制按钮偏移量配置，以及控件悬停自动隐藏。

- 主页：https://github.com/luckyoubest2/Orca-pinner
- 下载：https://github.com/luckyoubest2/Orca-pinner/releases/download/v1.0.2/orca-pinner-v1.0.2.zip

清单：
- [x] 图标已缩放到 80x80（base64 PNG，使用 `scripts/png-to-base64.js` 生成）
- [x] 链接（主页 / zip）已验证
- [x] zip 内含 `package.json`（含 version）、`dist/`、`icon.png` 与 `LICENSE`（MIT）