### PR TITLE
update orca-import-export to v3.0.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -22,17 +22,17 @@
     "author": "Peng52050",
     "id": "orca-import-export",
     "name": "Orca Import Export",
-    "description": "A multi-format import/export plugin for note migration with highlight syntax conversion support",
+    "description": "A multi-format import/export plugin for Orca Note with highlight syntax conversion, Anki card-making, resume import, and interactive UI.",
     "category": "Productivity",
-    "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" width=\"64\" height=\"64\"><rect width=\"64\" height=\"64\" rx=\"14\" fill=\"#3370ff\"/><path d=\"M20 28l12-12 12 12\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><path d=\"M32 16v24\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\"/><path d=\"M20 36l12 12 12-12\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><path d=\"M32 48V24\" fill=\"none\" stroke=\"#fff\" stroke-width=\"4\" stroke-linecap=\"round\"/></svg>",
-    "version": "2.4.7",
-    "updated": "2026-07-14T15:04:00Z",
+    "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"80\" height=\"80\" viewBox=\"0 0 80 80\" fill=\"none\"><rect x=\"1\" y=\"1\" width=\"78\" height=\"78\" rx=\"18\" fill=\"#16213E\"/><path d=\"M40 24 V8 M40 8 l-7 7 M40 8 l7 7\" stroke=\"#4A8CFF\" stroke-width=\"4.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\" fill=\"none\"/><path d=\"M40 56 V72 M40 72 l-7 -7 M40 72 l7 -7\" stroke=\"#7C5CFF\" stroke-width=\"4.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\" fill=\"none\"/><rect x=\"24\" y=\"30\" width=\"32\" height=\"20\" rx=\"5\" stroke=\"#FFFFFF\" stroke-width=\"4.5\" fill=\"none\"/><path d=\"M31 37 h18 M31 43 h18\" stroke=\"#FFFFFF\" stroke-width=\"4\" stroke-linecap=\"round\"/></svg>",
+    "version": "3.0.0",
+    "updated": "2026-08-07T02:03:01Z",
     "home": "https://github.com/Peng52050/orca-import-export",
-    "zip": "https://github.com/Peng52050/orca-import-export/releases/download/v2.4.7/orca-import-export_v2.4.7.zip",
+    "zip": "https://github.com/Peng52050/orca-import-export/releases/download/v3.0.0/orca-import-export_v3.0.0.zip",
     "translations": {
       "zh": {
         "name": "Orca 导入导出",
-        "description": "让笔记迁移更简单 - 多格式导入导出插件，支持高亮语法转换",
+        "description": "让笔记迁移更简单 - 多格式导入导出插件，支持高亮语法转换、Anki 制卡、断点续传和挖空语法",
         "category": "效率工具"
       }
     }

--- a/plugins.json
+++ b/plugins.json
@@ -1,645 +1,1289 @@
 [
+
   {
+
     "author": "litcu",
+
     "id": "task-planner",
+
     "name": "Task Planner",
+
     "description": "A GTD-based task management plugin that helps you plan your next steps.",
+
     "category": "Productivity",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAABauSURBVHhezdxnbBzpfcdxInkRBE6A2IZ9yElcksuyrAc7QQK/SBwEMPIqAdIPtgE7zjlObNjwIfG9sH1F5SRSEsUiikVi7+Que++dlMSyYidFSaRESZZVVhK5LNt/wf95ZsjZmdndIUWd74Avlne6E6DPPTPPzvPMTFD8rx5UJpyw3Iz/8IE5/sN1c9xH1H1z3MdCJ+7xTq4K3TXHnaLumONOU7d5Z26b486u8BKXWTGJS+aYJKFzi7wLC7xk+pwzRyfPmaMvzu6XMsNLo6bN0emU2WxgTZkNl6hJXsYEL5MaNxuyqOtmQzZ1jZdDjZkNV6hRsyGXGublDfHyB3kFvKiiAV5xn1CvOaqkh1dKdZujKvtvRpV3DwTF//rB8teSHHjn9Au8c9qChE+p50g4Qz1DwtlnSEh8ykt6wjv3WyScf4yE879BwgXqERKSqYdIuEg9QHzKA8SnriM+9T7i0+4jPv0e79IaL2MVcdTlVcRl3uVl3eFl30Zc9griclYQm3OLd2WZd3WJl7vIy1tAbN48YvPnEVswxyuc5RXNILZoGrHFN1kxJWZe6RRiyqhJxJRP8CrGWdGVNxBddQPR1dd5xms80xiiTaOIrhmFoXYE0Y03EFneZQuikUd48R89QNzH67xP7vNO3EPcyTXeqVXe6bu8T+/wztzmnV1BXOItVmzSMu/cEu/8Iu/CAi95nhVzkZpDTMocYlJneWkzvPRpVnT6TURfosyIzpjiXZ7kZU7wssZ52Td4OdcRfeUa7+oYy5A7yssb4eUP8wqGYCgcZEUVDfCK+3klfbzSXl5ZDyuyvBtRxn5EVnRZguiwJUBVPBHwiPE43DyHU8NL+5zilXO8yIouDljZaQmK/2jdTIfta+EJgIHxpIAHwRMAteCJgFrwRMAiAdAfnjDy9gBNfRyQJg0GqIYnAmrAUwBqwUsR8FL94MlHnxY8OaA/PPno04C3B1jVQYD3zTRh+MTzBegPTwS8IACq4slHnwSPAargKQA14ImAWvBEwAB4kZWdiKrpFQA/lgEeFZ44+rzw/Jz3vCYNLXjC6NOCJwJqwRMB/eApAc8+0453kEnjAHgHG3m/W7zIqg5E1fYgsrqdAO95Ax4J3qKAt+AHTwBU/bqiMmlkCXjZIp4444qTBgc05I7BkDcKQz7BjcBQQHjDMBQSHgeM0jJpSGZcOZ434Il7ZvqSrBlPMeMuw5C0hNAz8wg+NQvd6RnoTk9D9yl1E8FnKDOCz95E8FkzghOnEJw4ieAkoXOTOH5uHMfPUzd4F27gePJ1HE++xrs4huMp1CiOp47w0oZ56UM4fokaxDEqYwDHLlP9OJbZx8vq5WX34O2cHrx9tQehhYTmA08++mR4kdXtiKrrRqSxTQXwtADoB08EjEm6Bd2pOcR/ehP/mjOL96uW8HH9Ck42ruBEwwpO0Ke0JurWfs238Enzsqwl/tlCn0v8c69F71rFFiSfC/ikTdo8r533QfM0vlc9jr+82o9j2Z0IK+6FoVTDoSvB8wY8uWpOSHzif/Sp4BmSlhF2Yho/LJzHwMITPN+wYcfugs3pht3pgc3lgd1n7sCx30dj8v/WT7sOFzZ3HFh48BJJXQuIz+mGrrALhnIOqIonAgp4kcY2DmhqFQCTBEApnp+RF510i+F92rCCV1t2ONyA1e7Bxq4br3ZdPJu/nEeb3VcOlZzYdDix63bD5fagfeYR/uxqD0JKuvyf9yR4DLC+SwS8a05I+q36yFObNM4tQ3dyDj8tXYB1x4Edpwcvd1z77QbKebTZ1HJoasPhhAdA1fgawnLaEV7hA08ENAqAplYOWNMsAJ4TAAPhJS0jMnEJf554ExN3LGzkff7wtANSVqcLm9sOfN94HW8XtiGy0geeZPQxwIZOAfDUHXPCucfqeCJgkmT0nZrHD4v46Nu0uQ8AqALwOinQDo4n5vJ4UHpjFcdz2xChAU8JeF4AVMOTfWUJPjGDxJY7cLg87Fz3O8GjFHCHw6NsbjdGbz9FTF4HwioFOD94kTUtiGrsQGRtkyWIVpVpYTQw3hJizi8h9OQ0MnvWvA9fBdgbxFOgvR6eCDix9hzvFHQirKo9IJ4M8LaZVpUD4e0BnppGdq8EUAH2BvEoBdzr4YmA46vPkFDQwQED4EXWNiOqqR2RdY0i4COfk4b0Mi3mwiJCT91EljgCFWDyVABeJwXc6+NRfgFV8ETACAZ45raZ9jMC4XkBiiNQAfZZ4x0h4NozJBR2IKy6TTn6ZHiRdU2Iam5DRP0e4EOVGVe+QLDAAU8LgB5/gCoAr5MC7ejwKJtHBGzngGqHrgSPxQAbLEG0DUk7af5GnriqHJO8gNDTZmT1rcHpE1C4OpAj+In+/Q27y3cOtZyaoisPOZhXdhmgsTUgXkR9IyJbWqWAD5SAKkvyBBjyqT9AJ5xuJ+wuJ1xuF7YdTrxQAZO2aXdjm50OlL+mHHEHG3kv6Iuyy40tt4f9LP91wvMCLGrjgGrnPQneHmBDvSWINsATUh74H317C6P+AJ3YdTpRtWjDP9Vu4+fdO7j3ysEQFTBCG3Y3Hr/cRp6pF2ezapCUU4dzV46uxJxaJOc14ubKOrZcbm2AphYlnhywoQGRrS37gLQJHhhvHtEX5xFyZkoV0OFyYvC+HW+lW/EnKZv4g/Ob+GHbDmwu34fzLoDxhTV89+fJ+I//S8MPPkjHD35xdP3nL9Lxbz9OwtXqbtgAVTxVQH94ckC6/SI+ZV0dT9wEF1aVo1N8AToBuJA9ZcMXkjehz7YyyG8Ub+H5Dh2mSjw+Al14urkLY/s1XKnqZiPxKMs19iDP1IOFtcfeI1CC5wVY3IqwmuaAeAywrRkRjXUCYKoAqMDzXpKPTplDyNlJGaAwmpxOzD5xIPaqlSH+4YVNfDK0C4eLlreUeFLEXQ+w4xain48wGuWE92JXHW8f8Ok+YAC8iMZ6CWASAd5XxZNvRUanygH3IWiysDmdmHzsYHAFMzY2u27SSV8FTh4h763tydf7bI5D5+uw9QZ07Y/A2qaAeAywvQkRTSJgmgDoB482wRlgogjoUSCIiPC44Pa4sGELPAvvpZhpDzbjBkwFjmffByxp4YAB8CKa6gTAWksQ3XIWn3ZPddKQb4JHp84iJHECWX2rqoCvlQBGI87lcbFz6o6TfxVRYBwmBRzH2wd8ygHrGmWASjwG2NGE8GYRMP2eCp5yKzI6bebNAAp4G3YnnB4XTMs2/HJgB7NP7QxRgXHQFHA+AEv3Ab1G3x6eANhMgI0i4IKZ7tcTZ1y1kSdugjPApHFk9a/C6T4iQAkejbr0iV18KXUTv5e4iX+p22aAG/SHlaNoTYG2D6cEbEYYjThVPD7yCC+iuRYRnY0Ib62xBNHdogzQ7yY4v4MgOn0GuqRxZB4VoIBHX3MIL21iF19O3UTwZSv++KIV327cxo6LbwYpYLSkgAsMGCoCSs97kpFHeOEtqoDy0ae87Sw6fRq6pBtHAygbeSKe7rIVX0614ptlW7j94jUOYQWaOp4XYFkTQsRznnz0SfA4YIMEMGNVHU9x59Q0dOfUAWm23RIwPB4X+16oQJPhqY28tzJ28Hc1TjyiSwfw73H040HaAfCKLiE14MkBQxvqlXgMsFYCWIOIrgaEt5kIcM5M9yr7Ou9JbzszXLopAN5VABLe6ksHTo3sIGPChrmnDvaVRoEnAHrjWRne21k2vJP1BHUjS5heuIUh8y0M3byF4QM0OLUM88o6A/NGVML5BAyAF94qAaS75OMu3/Ux8iR3Tl0SAa8rAOlLsMvtxM+6dvD7SZvsWliXaUXlgo39czme12Gbxkce4cWm/wb/c7oU73+UgR/9Kgv/fZh+mYn3PriEzrFZfv0bAM8LsLwJoY11qpOGFC+8zYSI7nqEtxtlgHI8dt7bv+3MkGGG7rwSkKLlq5927uCLqZsIy+Lnsb8u3WKrMXsrMoqRx6HpsI1Of4SfnCnHByez8PNTeQfvpFgufvJRDvomFtnhL8dSax+wEaEinC+8VpMM8OKsmR4xUMOT33bmD5CuPBpu2fBHyZs4lmFliF9Nt+LDgV02Cq20wCnHEyaMvynfYbtiq+sPsXj/t4drnbdw/zFu/+YZP3wdgUefErDWDx4ffQywpw7h7dUi4J2AeHTPniFjCroL11QB6bKNriLoCzBfjdlESKYVX0zZxEdDO3CDX13sTRiZVnxJGKV3XtoBuLHtweGCd1seD15pxPMCrGhAKDvfec+4crzwdiMH7CDAlFkzPdyiNmnIb/Q2XPYNSLMwHZ60Ir383IF/MG2zcyFDTN3E2bFdZE3t4itpVnbYinh3X9rh8rzGJZtipg08achTAionDSkeB6yFngPOcEBfeOLdogxwEroLY6qAYjShuD1OPNlyMkQagaGZVvzpJR6Bcrxt3H1Jt1W8Bp5PQCWSv/YAKxsQSmB+Rh6vGhG9BFglAGbfVsy4avcqGzInoUv2DyiORlqhfrItQczi50Vxcvm84HkD1iNkD9A3XnhHNcJ7a6DvJMA0AlxRzLhyPA44wQEH/AMyRJsTDjdH/HvjFltkpQnmrwjv1ecHTw6oo1lWNuOGt3nj6TuqEN5HgJUEOM0B5aNP5UZvQ9YEdBdHAwMKVxoM0ePC+qYD77Vt492GbSw8t8P9RvBeHzC+SgBUPXT38TigSQKYs6KOJ3s6SBOgbEGUELedTtjdDthcDuy6Pl94SkCjCp6RH7YiYGclB+yqsATR87j0OGkgPHrEwJA9Dl3KCDIH7qgDiouiwrL8PuT+LbYKEOHX5BviPnPut3+ppkQ5SHuA1XXQ0eGqgieOPMJjgP1GDkgPMsdeIUAVvL1nNPjDLVoAnR4abXxVmUZeoNG26XBhm34vlV9TJBt1hLgNjwLkoHkB0qGqMmlwPAGwq4IDdpeJgMuqk4b8ySBDzg3oUofVAW1O7LqcqFqSbKxvOLDtZzmKbtF4/GqLbUGyjXWVzXFf0SY8bZx3XZ+FlXb+HEoYrSkA/eIpAKc4oBqeVkBhxh1cl2ysnxM21t0qu2NCio11lc1xf33nZ8n4dXIZQ9ig/1EqOFpSB1TBE0YfAxyolgBeXQqIxwCvXIcudcgbUDjPsY11sw1fuCDbWN+lw1SJx0egE0+tOzB2HHRjnW+Y51R1Ynj6FhuBcpSDxADvPUW8sRY6mmFlM64cT99dzgF7Si1B9PIGBhgAj55LY4BpEkDJREGH7+xT+cb6Dhx+RqCISCNRviHOEhZHlXlYu8KnHOSg2eD2BgyAxwAHq6SAiwHxGODVa9ClDXJA2pWTfV2h+2AmH9vxyfAOCmZ2Gdymj5lXHpulpZvibEFU/pAMZfdKjnHgHFLAGoR0VAbE0/eUccDeEkuQIWPSTG+/UJs05I+UMsD0QWQOKgE5Iv+uBzjhBt9NCzQL+0zxPe/w5zif0cQjBTTVQEdgshlXjscAhyqlgAsB8Rhg7pgfQBWEw6aAewN4lApgcGeFYsaV4+l7S6WAE2Z694pPQMnDzAQYfGngzQIq4N4snhQwzmRCMIGpHboSPAY4XAF9X7EliN76Qy+uUcCpPAkelTcqAN7mNxd9Rngv7HZse/hzbW6Afdrhxo7HxX6mdnCAmViC5wVYQ4Dl+yPPB56+r0QGmO8HUPIYPQPM6JcBqkAcJgXcPiBd0ZjXnuNq2xJqx1ZR1H0LHeZ1zK5bUNq7goLOZSw+eslACVsB5gdPHVDlvCfBY4Aj5dD3F1mC6H1Tsflz6nh7hy5/B4E3oMbLLy0p0PbxKLvbjfapdfz7iS689Y/F+ObPGpDZMI+TpZPQv1uOd09242vvmTC1+ozd66dA84OnAOwuU+LJAfuLZYAFAqAfPHp5Q1T+CIIz+pD1mQDu/8FpVNnhgQ0uxH2/Gg3X1tim+y/zb+C/kgfZ4Xzsn0tQ1rfCDmcFnB88DujCxL0niKs1ckB/eFLAAQZ4nQOq4KkBHrvch4t9t+DwuP1+QdacAs4bT8xKK9xbOwywov82AzxbaUbou+X42/eb8O6pbjx8tYUtF63QKP97OZoccPzeE8TWVEMnAvrBY4CjZdAPFFqC6FVx9KYzn3herw4ZxttZffhF0wx7dJ62KRUgB0kBp44nBYz6biUbafTXrwvG8a3/bcHMmgUbDju23U7lOVAFzDsbHHCjdeE+QmrLECrC+cHTDxRJAa+ZYwtn1PFUAENyB/Ct/GGsP7Nim65B5ShaU8D5xpMCfuPHdTAN32WH6qnSKfwoeZBhWn0tJijAvPFeOe3sPu4P+8bxlaYi6HsD4zHAsVKEDRYIgEUCoD884eU1UYVD0GX2IHtwBW54DjcKFXCBAcXuv7Di6fYuu4x7bN3Bw41t35d0CjBvPHH0za4/x9dNJhzvLtGEpx8slADmEOC06qQhxxPf/BNa0I+vZ/ehb+Ex+15Gj80rkHylQNOOR225aTWa//ubTnoS6eDnPILbcNrZBefjF9v4TlMPvtoSYPRJ8FjXShA2lC8AFk9rxmMVDyI4rxd/caUXlTfW2Js76LF5R6DgK7py/uwiOLvThcm1p3i3sRtfbSxCWJ92vLChAgnglTEzvR5TddJQwRNfmWQoGYCusAdhWZ34duU15IysoG3uITrmH6FdbE7y8/xD/rlAnw+9P/d6cPAWJcn/fnEd7Uu8Nvb5AB3LD1A5fRvvd40hwWjEWy0B8ERACR4DvF6MsJE8AbDkpnY82TunIkr7cKygE8eutCP8SgcicoXy2nn5bUKtvIIWRBRSzYgoEipu4pU0CjUgvLSeV1bHK6dqEV5B1SC8kqevoky8aiPPWC1UBb2pCmGmSoTViFXg7dpSfKW5CMHdBHZwvLDhfCngqJlezOoT0A/e/tvOehFZ3oPw8m7oqYou6Cu7oK/qhL6qA/pqqh16I9UGvYlqhb6mhVfbDH1dE6++kRXW0MBrrOc11SGsmapFWAtVg9BWyoTQNhNC2437dVQjtKMKoZ1VCOmsREgXVYGQbqocYT30PS/wdz3poSvFY4A3igTAXAFQDU8A9IsnvHPK7yuTAr3EQcOjVer3KitvO1PsZwRYGGUjMACeT8DRXAGwVAA8JJ5PQC14Pp7HDYzn5+Yf2Sa4Tzxfoy8AXthIHvTjhSLgsJneqayGJ500AuIdZuQdBE+4V9n/yFPfBNeEp3HkEd4e4NhVGeBh8XwBasETAAPj1QUeeWpbkVrw5IAB8MJGc6GfKBAA84bM9EZvVTxfgFrw9l7YdTR4ytGnBS/wwuhh8ETA0GtXBMByAVAL3kEmDQ14PgG14KlNGiqb4JrxRMAhAdAHXtjYVQlgPgFOHGjS0ITnC1ALnuqk4eu89+ZnXDkeazJfBBycizVOI7p0DIayUV75CK9imFc5xKsaZEVVD7BXobNMfbyaXl5tD6+um71jj9XQyWvs4DW1sxfX0LtX6O0X9P4BVlszr72J19GICKqTamAPt9DjBayeOl5vLcJZNeymR7rtjO5bYQ1U8wareEOVvOEK3kg5W5ZijZWy6BKNdb2YfVVhjRfyJgr4uW8yH/qZYoRez7EGGQqGBqIrxi1RhQOWyKJ+SxRV3LdfSS+vtIcVWdZtoZfwsyo7eVUdvOp2nrGNZ2rl1TTzapss9L4pil6bRO9dYTXU8xqpOgs9CU4PM9PjpOHNNRZ6Jo3VZuK1G4WqLXSfMquzktdFVVjovhVWTymvt4TXV8zrL+INUIUsWl2h61vWCJXHG8210IRB0aijwqbyLKE3cu7+P2XUXAh1j7ulAAAAAElFTkSuQmCC",
+
     "version": "0.9.0",
+
     "updated": "2026-05-010T23:42:17.230Z",
+
     "home": "https://github.com/litcu/orca-plugin-task-planner",
+
     "zip": "https://github.com/litcu/orca-plugin-task-planner/releases/download/v0.9.0/orca-task-planner-v0.9.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "Task Planner",
+
         "description": "基于GTD思想的任务管理插件，帮助您规划下一步行动。",
+
         "category": "效率工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "Peng52050",
+
     "id": "orca-import-export",
+
     "name": "Orca Import Export",
-    "description": "A multi-format import/export plugin for Orca Note with highlight syntax conversion, Anki card-making, resume import, and interactive UI.",
+
+    "description": "A multi-format import/export plugin for Orca Note with highlight syntax conversion, resume import, and interactive UI.",
+
     "category": "Productivity",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"80\" height=\"80\" viewBox=\"0 0 80 80\" fill=\"none\"><rect x=\"1\" y=\"1\" width=\"78\" height=\"78\" rx=\"18\" fill=\"#16213E\"/><path d=\"M40 24 V8 M40 8 l-7 7 M40 8 l7 7\" stroke=\"#4A8CFF\" stroke-width=\"4.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\" fill=\"none\"/><path d=\"M40 56 V72 M40 72 l-7 -7 M40 72 l7 -7\" stroke=\"#7C5CFF\" stroke-width=\"4.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\" fill=\"none\"/><rect x=\"24\" y=\"30\" width=\"32\" height=\"20\" rx=\"5\" stroke=\"#FFFFFF\" stroke-width=\"4.5\" fill=\"none\"/><path d=\"M31 37 h18 M31 43 h18\" stroke=\"#FFFFFF\" stroke-width=\"4\" stroke-linecap=\"round\"/></svg>",
+
     "version": "3.0.0",
-    "updated": "2026-08-07T02:03:01Z",
+
+    "updated": "2026-08-07T02:27:41Z",
+
     "home": "https://github.com/Peng52050/orca-import-export",
+
     "zip": "https://github.com/Peng52050/orca-import-export/releases/download/v3.0.0/orca-import-export_v3.0.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "Orca 导入导出",
-        "description": "让笔记迁移更简单 - 多格式导入导出插件，支持高亮语法转换、Anki 制卡、断点续传和挖空语法",
+
+        "description": "让笔记迁移更简单 - 多格式导入导出插件，支持高亮语法转换、断点续传和挖空语法",
+
         "category": "效率工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "cordinGH",
+
     "id": "dockpanel",
+
     "name": "Dockpanel",
+
     "description": "Allows detaching a panel to create a \"floating window\"-like experience.",
+
     "category": "Visualization",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 256 256\" width=\"64\" height=\"64\"><defs><mask id=\"arrow-cutout\"><rect width=\"256\" height=\"256\" fill=\"white\"/><path d=\"M 120 181 C 140 196, 200 200, 212 146\" fill=\"none\" stroke=\"black\" stroke-width=\"40\" stroke-linecap=\"round\"/></mask></defs><rect x=\"10\" y=\"85\" width=\"160\" height=\"160\" rx=\"24\" fill=\"#2C3E50\" mask=\"url(#arrow-cutout)\"/><path d=\"M 120 181 C 130 196, 200 200, 212 156\" fill=\"none\" stroke=\"#2C3E50\" stroke-width=\"20\" stroke-linecap=\"round\"/><path d=\"M 188 154 L 236 154 L 212 122 Z\" fill=\"#2C3E50\" stroke=\"#2C3E50\" stroke-width=\"6\" stroke-linejoin=\"round\"/><rect x=\"182\" y=\"55\" width=\"60\" height=\"60\" rx=\"12\" fill=\"#2C3E50\"/></svg>",
+
     "version": "2.4.1",
+
     "updated": "2026-07-08T12:00:00Z",
+
     "home": "https://github.com/cordinGH/orca-dockpanel-plugin",
+
     "zip": "https://github.com/cordinGH/orca-dockpanel-plugin/releases/download/v2.4.1/orca-dockpanel-plugin-v2.4.1.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "Dockpanel",
+
         "description": "允许将一个面板脱离出来，形成类似于「小窗」的体验。",
+
         "category": "可视化"
+
       }
+
     }
+
   },
+
   {
+
     "author": "cordinGH",
+
     "id": "tabsman",
+
     "name": "Tabsman",
+
     "description": "Adds a tab manager to the sidebar for building a tab list for each panel. Open tabs in the foreground or background, with tab-preview, workspaces, drag-and-drop, pinning, favoriting, and recently closed tabs.",
+
     "category": "Visualization",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect x=\"3\" y=\"4\" width=\"18\" height=\"16\" rx=\"2\"/><line x1=\"9\" y1=\"4\" x2=\"9\" y2=\"20\"/><line x1=\"3\" y1=\"9\" x2=\"9\" y2=\"9\"/><line x1=\"3\" y1=\"14\" x2=\"9\" y2=\"14\"/></svg>",
+
     "version": "3.9.1",
+
     "updated": "2026-07-08T12:00:00Z",
+
     "home": "https://github.com/cordinGH/orca-tabsman-plugin",
+
     "zip": "https://github.com/cordinGH/orca-tabsman-plugin/releases/download/v3.9.1/orca-tabsman-plugin-v3.9.1.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "Tabsman",
+
         "description": "在侧边栏为每个面板构建标签页列表。可在前台或后台打开标签页，并支持标签页预览、工作区、置顶、拖拽、收藏及最近关闭等功能。",
+
         "category": "可视化"
+
       }
+
     }
+
   },
+
   {
+
     "author": "cordinGH",
+
     "id": "tune-theme",
+
     "name": "tune theme",
+
     "description": "A style plugin that restructures block styles, provides a theme switcher button, and can run alongside other themes. Active on enable.",
+
     "category": "Theme",
+
     "icon_svg": "<svg width=\"64\" height=\"64\" viewBox=\"0 0 64 64\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"0\" y=\"0\" width=\"64\" height=\"64\" rx=\"14\" fill=\"#F0F2F5\" /><g><circle cx=\"37\" cy=\"32\" r=\"16\" fill=\"none\" stroke=\"#9FA7B3\" stroke-width=\"2\" /><circle cx=\"27\" cy=\"32\" r=\"16\" fill=\"none\" stroke=\"#646F7C\" stroke-width=\"2\" /><circle cx=\"32\" cy=\"32\" r=\"1.5\" fill=\"#4F5964\" /></g></svg>",
+
     "version": "3.6.2",
+
     "updated": "2026-07-08T12:00:00Z",
+
     "home": "https://github.com/cordinGH/orca-tune-theme",
+
     "zip": "https://github.com/cordinGH/orca-tune-theme/releases/download/v3.6.2/orca-tune-theme-v3.6.2.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "Tune 主题",
+
         "description": "一款样式插件，对块样式进行了重构，提供了主题切换按钮，可与其他主题叠加运行。插件启用即生效。",
+
         "category": "主题"
+
       }
+
     }
+
   },
+
   {
+
     "author": "Samuelxiaozhuofeng",
+
     "id": "aiichat",
+
     "name": "AI Chat",
+
     "description": "An AI assistant plugin for Orca Note with multi-model chat, note tools, skills, memory, web search, and file understanding.",
+
     "category": "Productivity",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 80 80\" width=\"80\" height=\"80\" role=\"img\" aria-label=\"AI Chat icon\"><rect width=\"80\" height=\"80\" rx=\"18\" fill=\"#151A22\"/><path d=\"M18 24c0-5.5 4.5-10 10-10h24c5.5 0 10 4.5 10 10v18c0 5.5-4.5 10-10 10H39.2L27.6 62c-1.3 1.1-3.2.2-3.2-1.5V52C20.7 50.6 18 47 18 42V24Z\" fill=\"#4F8CFF\"/><path d=\"M29 29h22M29 39h15\" fill=\"none\" stroke=\"#FFFFFF\" stroke-width=\"5\" stroke-linecap=\"round\"/><circle cx=\"58\" cy=\"56\" r=\"10\" fill=\"#39D98A\"/><path d=\"M58 50v12M52 56h12\" fill=\"none\" stroke=\"#102018\" stroke-width=\"3.2\" stroke-linecap=\"round\"/></svg>",
+
     "version": "2.0.1",
+
     "updated": "2026-06-14T06:52:09Z",
+
     "home": "https://github.com/Samuelxiaozhuofeng/AI-orca-plugin",
+
     "zip": "https://github.com/Samuelxiaozhuofeng/AI-orca-plugin/releases/download/v2.0.1/aiichat-v2.0.1.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "AI Chat",
+
         "description": "为虎鲸笔记提供多模型 AI 对话、笔记工具、技能、记忆、联网搜索和文件理解能力的智能助手插件。",
+
         "category": "效率工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "SaXz2",
+
     "id": "bullet-theme",
+
     "name": "Bullet Theme",
+
     "description": "A clean Orca Note theme with refined editor, sidebar, query, quote, code, tag, search, and mirrored block styles.",
+
     "category": "Theme",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" width=\"64\" height=\"64\" role=\"img\" aria-label=\"Bullet theme icon\"><rect width=\"64\" height=\"64\" rx=\"14\" fill=\"#f7f1e7\"/><circle cx=\"19\" cy=\"20\" r=\"4\" fill=\"#2f6f73\"/><circle cx=\"19\" cy=\"32\" r=\"4\" fill=\"#c7604c\"/><circle cx=\"19\" cy=\"44\" r=\"4\" fill=\"#5b67a6\"/><path d=\"M30 18h18M30 30h14M30 42h20\" fill=\"none\" stroke=\"#2f3340\" stroke-width=\"4\" stroke-linecap=\"round\"/><path d=\"M11 10h42a4 4 0 0 1 4 4v36a4 4 0 0 1-4 4H11a4 4 0 0 1-4-4V14a4 4 0 0 1 4-4Z\" fill=\"none\" stroke=\"#2f3340\" stroke-width=\"2\" opacity=\".12\"/></svg>",
+
     "version": "0.1.0",
+
     "updated": "2026-06-08T05:30:00Z",
+
     "home": "https://github.com/SaXz2/orca-bullet-theme",
+
     "zip": "https://github.com/SaXz2/orca-bullet-theme/releases/download/v0.1.0/orca-bullet-theme-v0.1.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "Bullet 主题",
+
         "description": "一款为 Orca Note 设计的清爽主题，优化编辑器、侧边栏、查询块、引用块、代码块、标签、搜索和镜像块样式。",
+
         "category": "主题"
+
       }
+
     }
+
   },
+
   {
+
     "author": "SaXz2",
+
     "id": "easymotion",
+
     "name": "EasyMotion",
+
     "description": "A Vim-style EasyMotion quick navigation plugin for Orca Note, supporting Chinese, Pinyin, and English mixed search.",
+
     "category": "Productivity",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 80 80\" width=\"80\" height=\"80\"><circle cx=\"40\" cy=\"40\" r=\"38\" fill=\"#1e1e2e\" stroke=\"#89b4fa\" stroke-width=\"2\"/><circle cx=\"32\" cy=\"32\" r=\"14\" fill=\"none\" stroke=\"#cdd6f4\" stroke-width=\"4\" stroke-linecap=\"round\"/><line x1=\"43\" y1=\"43\" x2=\"56\" y2=\"56\" stroke=\"#cdd6f4\" stroke-width=\"4\" stroke-linecap=\"round\"/><polyline points=\"26,28 30,34 24,34 32,42\" fill=\"none\" stroke=\"#f38ba8\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg>",
+
     "version": "1.0.0",
+
     "updated": "2026-03-20T07:30:40Z",
+
     "home": "https://github.com/SaXz2/orca-EasyMotion-plugin",
+
     "zip": "https://github.com/SaXz2/orca-EasyMotion-plugin/releases/download/v1.0.0/orca-easymotion-plugin.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "EasyMotion 快速导航",
+
         "description": "一个为虎鲸笔记设计的类 Vim EasyMotion 快速导航插件，支持中文、拼音、英文混合搜索。",
+
         "category": "效率工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "SaXz2",
+
     "id": "folder",
+
     "name": "Folder",
+
     "description": "A document tree management plugin for Orca Note with notebook and folder hierarchy organization.",
+
     "category": "Note Management",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M3 3h18v18H3z\"/><path d=\"M7 7h10M7 11h10M7 15h6\"/><path d=\"M12 3v18\"/></svg>",
+
     "version": "1.0.0",
+
     "updated": "2026-03-20T07:30:54Z",
+
     "home": "https://github.com/SaXz2/orca-folder-plugin",
+
     "zip": "https://github.com/SaXz2/orca-folder-plugin/releases/download/v1.0.0/orca-folder-plugin.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "文档树",
+
         "description": "一个为虎鲸笔记设计的文档树管理插件，提供笔记本和文件夹的层级管理功能，支持拖拽排序与数据持久化。",
+
         "category": "笔记管理"
+
       }
+
     }
+
   },
+
   {
+
     "author": "SaXz2",
+
     "id": "link-icons",
+
     "name": "Link Icons",
+
     "description": "Automatically fetches and displays website favicons for links in Orca Note with multi-source support and local caching.",
+
     "category": "Visualization",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAACFJSURBVHhevV35U1zXleafmR/mp6lM4i12PHZiJzNJJpVkklRmMpNUWZZsawOhBZpmb0ASaF/RYu2WJUuyJBCLAAHd7IhVIEBiR4hF0M0O3fRypr5z331bd7PEcl7Vqdf9+i33fu/s99zbET6ftzcQCDh9Pp+OvArpj610XP+78ZjXK477/X4nniNpbm7O+ay711lcVum8fP2OM+v4eac1/ZBzZ/xeZ1RcujPKkhZEu+L3OuPTDzuzjn/pvHT9jrO4rMLZ9bzXOTs3Z7g3nmVsj3lvJv3xcOcYScGsJ8Ln883TP2ibmHSSo6aBzl35hpL2HaMoazpt2Z3CtN2SRlHWDIqO30s7E/bpCN/FMfyGc7bHpvE1m3cnU1RcOt/r3NVv+N4TTpf5sd/b5vP55iL8Ph8/0e/3kd/vD0P4Tf+7/B7uGp/6kOmZGSqvrKEDJ87TtphU+jQyjj6LTqCte1Io0mKjqLg0jSxpFMlkY9oeC0pV9jgmzsG5O5Q9juFem3bE06fbLXzegZNfUllFDT9bblq7V+rX2kkB0AkOXAOA4Si4AXIbHR+nm3fzaE9SJm3YbqHPdiQwGAawYm20ZXcyfR6dQBuj4mhTlJU+2xHPx7bHpPDvAAigbNmVRJ9Fx9PGSCttVF4Cn4d7SmCVc3E/PHNP4n66efcBjYyNhwHy7+mz1k8TgPoTVuMw83kacBDT67dzuTPgtq0xKSrXAAxwIbgFYAGg5H1H6dSX1+j2/QIqddRQQ9MT6uh6Tt29/dQ3MEj9g0PU0ztAHZ3PqaH5CZU6qvncU19+xdcCsI1RVr7nNjyLnyOAB2cCyO0xqXT15l16NTFpAtLcj3B9Dj4mAPSGA3DliwMB/W9CXJeXvZRfVE7R1gwhSjGS29K5Q+CKTVHxFJOcSdkXv2YR6+sfopmZWfIuLxMF/Ey4n8+7zMeWQR4Pf/Z5vfwbno3zvN5lvravf5DvdebS13zvjVHxzJ3bdeoBL23DNgvtiEujvIeltLzs0YGo58bgvoYjAeCKHBjus4/8SkeJAnyjZz19lHbwFL/tbXsEF4DAHeAMcMKR0xeporqeJiYnxbUAYXmZFhcXaWFhnuYXFsR+fp73C/xdHNM+67/P87W4RyDgAzcwh1XUPKYj2Rdp6+5k5ky0YUdcOhM49JOtsWTLOk5d3b0KL0r1pQfSDJgZg1UBXI0E14Ebcgoe0eZdScxh4DYpQpt2WLnBF67douc9fSqXud1uBkAApYAyrwfI9Jvp+LzpXO34HLmXlvgZ4Nxn3b104dpt1qWsLpgjRfvAoV/sTKT7+cUUCAgmCM+B5uN6AA0iHO5i8zFxMSzcsTOXWTTwlqW4frErkT6PTqQzF69Tb98gBfx+FkkzAOo+iMOCwTEDrOdC3EfcV9Dc3BzvfT68sAD19g3Q6QtfMWh40eBEtBNt3rA1lg6fvkhT08Jar9RnM62RA803E5w39OIlJaQfZouo6jko80grpew/Rk0t7RSALvN5VZDMnCOPadwWSnw1cLTP4Tk01LPw8vw+HzW1tlPq/uO0KVJyo7Dan26PI6vtIA0MDetADEVGLEJwYPiT9eB1Pu+hHdZ0fqPYg7buEa7IjTsPmAMg2kK3GYFY7bseLO14MEiSIyWghvuFARiijbbduJPL4gsdye2PS6fPdySw1X7a9TwMJ5rFWADo9QaJsDzJvBcXtHc+Z78LDWBn1prOwO1K2EuPm1rZqLjdS4YOhAIlFIUDcL1kvI+xHdC/aGN9Ywu3GapGMgHEG35la3uHAqLEwwye+M4c6F12Rvj9oQDUoy5OhtWCa4KHIAQDwcol7z/GIo0tqDOqWAZ31ExshfWdN4u8TozN14Y6Lzwhcg3Q0IthVjfogzQuW3YDxCR62ik50ch1emwYQIiwEUDha2kXihNfDL+kaGu6wnlCCePBCM9crik+L1TDGYwwnQp1TL0mzG9MKwIpXCLzcbMawLVos2tqirKOneUoSM+J0OeDq+hEAWBQKGdEHNvM7CzFpx9SdZ4E7/CpC9wQKOnQnTE2WHwWOmtxcYE87kXyuhdp2b1IS4vaeavdKzSt/xo8B8449OLBk+e5T9JfhFqyph1UY2kz92kAhjUiiDYCbAyOZl9iSwXg2HjsiKfMY2f5wfDtQnU41DGQb3mRyO8mz9ICTbhmaGh8mkYmZmhubp7It0Tkc6tgfj9kbBeDuCxAzDx6hv1FGQQgDIXzL7EIC2BwNkY74cHDUtqwLVa9KUQ4ad9RcjpdKueZwTIeExwHLgNwXUNOOlXQTZ+fbaLfH6ijX+6tof/cX0P/d/wxpXzzlEpbR8i9uEDkhSEy3jMYjNUp9HWm9i7AZ/RynxL3HmbuQ8gHToSPm1NQEoILQ4qwXwnRxI+9/QOsDxBHgvsQjsFv6u2Hcxxa5+kbKf21gHeJXDNztP9eF32QUkE/spTRj+Pt9H6SnT5IdjD9JNFBb8bZ6a24ctp4upGaul8x4NI3lM62+Zni+0rtCEXB53M7/T6OqwEe+goA4XF8vjORExtmEDUAVSOiiS5CoYyDpwzhGWJaxJnYzB0JRRK8gbEp+t9jj+kHMeX0YUoFfZxWyfQzWyX9LLWCPrKBKpk+tlXQ29ZSBvR+3QsVRPO9g+nvAVKQlBgQtqraBu6rdLbhI6YfOEXLXsTcmiirAGpWWIgvtqKyCk4MyCgDCvbiV7dZJ4qHBjdE3yDsvZ5FmnDN0n8fqaM348oVkABgFX2UJgADgB/bHAycBPDntkr6t2QHvRVnp8LGYQZxpeetRKtFLWaC8w+HG32FDpSq65NtsVRYYjdwoQDQ5MZgg2mHk8kiy75RMoc6TtcUeTyeoIeGpnkK+JYo4es2+mFsGXPcR7YqldMAJMADUMyVANbmULkR33+SaKefp1VS/8gUv4zgZxjBEdkcYxvE8VAAhlYJII/Hza5ZnO2gcGksNtqyJ5l2xmeQa2paBVHjQJ0OxPbN3TxWngAPF4P7Kmoa2Plcq5hAdGs6x+htazn9lLkMpIhuaiUfB4C/zaplwN5SzwPIFfSRItrQl7bbHYooGwGQYmd+dmjAjNeajxlehBTlugbuuxRl5DiBjZ7ZDEYEm9PlYldFGI401oGHTn7JSU34buYHhyO4I4k32ukNSxmD8XEquErovfcSHbTvbhdb5FeuWep5OUUnC7rp/STBjYILK+hntgr6IMXBoPePSi5UOmqIfzVu0ov60uIih5UetzsoLl+NcD6SrvB1MRTB2W0l2z2pG7QKAvBeXhEjLbkPsWJLWwenpPRvLtSbl+ReWqBJ1wz9/kAtvZ+siSX24LyThd3IX7OrgnP98A3JS7eqBuideAG4HsQ3LOV0GtcEoAv1z9W40Ci+ItEKt2RoeIRevByl6elpPqYHfLW+gMvaO56x68ZcaBG68O6Dh6EBXFhcIKvtgKL7hDd+JPsSe+t67ltNofuXl+hJ3wR9kKK3stB3FfSHQ3U0NTPPfqF6zTxAX2Sx33yumX6cYBeAp4rroSfxMianZjl60dohwFtaWqKlJQmO4B44xqWOOrqXX0r38h9RTX0zLequwXm4BmRuvyT0GcMIx7IvKVxoY51oST1ACzA2DOCyBmDd4ybayBGHsDyIOOobW9kqmW/OHQgDJjjL0T4qgNAB+OP4ctp1+QkDZbiPdCH8bsprGGZ9yBZa4VoQuPBW1SARSSMmQEAGemR0nEbHxjnTgvvgZbx6NUl5RXbKL67g/cPSKg7LBCMI0HENhgAg4vq26D/D68BAlsxogz7dZqHax80KgDorfPLcFfZ/AB4GrFMzj6tv2AzSSoSQzN42Su/El7MISqv6XoKdIxBwn+Ro2WB+zuI8zc7Os9sDC8zgK/RuQjn97cRjvk6EeuI6pNdyC+30oMhBvf1DrLdgRZ/3DFBuYRkDKEB00IvhEf4NQHc+66EHD8upoKSCr5OcKF+mJCn2qZknaPMuIcowLCfOXWEA/X6fMyIQCLjASRhNk8OCGHeFPoTl1b+V1YjfmneJmntesVGAZZVchM8fpjiorX+S/IZQTQMReu5SaS+9YSlVfEONoD8R6oFTAUJ37wDdfVBC+UUO5rIHRXZqan1KVfXNVFBSSfnFDhVAfC58VEl1ja30uLmdcgrLKb/YztflFJTSy5FRNY9p5kJI4P28YsUvtDFGiFbmmEMDAkCkuwEaVwNYbDyyhvAF+i/Yv1qZoKfGJqfpN5k1rL8YAEQftip601JKmfc6QhgE4X4suxfo5atp+mVGJVtgvd/4jrWcoi62MPjo7PDLUcFFxQ4qKK7gfW5BGR/LL8J3HZUATDvlFpZTTkEZg47jAmQHvZpwqpJmdoOQbOjpG+BcqBwqhaFtxLCFBPD67RwxvmFJY0W59/BpFpfQ5j/Ykpl/BxfGX2+jt+LKuPPCB4RbUsEJhJevZtgt0ce4ksi/RFn3u+iNuHK+ThgUwcHvJzqoufcV3x9uSnVdMz14WKYCBW4L9VkjAaQgB+UUlFNjy1N+IeZ+yBcMDCDi+4+cEflQ6MFIC127lSMA9Hg8rr1HsmnzbuF1A8hv7uWzjAff1AxWaIIerHoKPWhXLLE0CJXsHF98hDFZIxdKMOHWdAw62ScUKkAJ+2wV9CYc61tPWYwXFxaprrGN7heCCzXQQgEHsPSfJYg5+WX0vKefvMvwcwHUko5ptLZBld26n69KqWCybERmzojhl6Mu1K/IoUkkTuubWtW4V09msWMy6TIQXAbP0iJtym5k66u3xsjC/PlwHU3PYBzXKDK4Dm4QBTwUc62N3rKCgzUu/DDZQT9Pq6Kh8RmanZ6iBw+FARHAVbJRgLjiOEQVIo09KO+h4DqpE8GNeQ8dVFxWQxMTTpqZmaGJiUmanp4J6iN8QpScwLWLjBMFT7sT9tHgi5fOiLqGZtdWRB5KNVR0fAa9eDnC0Yd2kxDArXBcGoRva4bojTi7mjwQIV0FvRlXRjl1QwyUfCkQS3AfIhS4IggF4QqxOyMtMrs0ZcKxJi81P+mg+/mlbGUlMADrkb2W2jqeUd/AEKffmlo72IjkFpQKkFkvCoIhKSqtopLyav5cUdNoYpR5tt4wNIiHAR64EP5ybX2TM+JubpFr8y7U2YnEQdqBk+yIhg/dQoEWfAxZ56mZOfrj4Tq2yEIXCn0Il2bD6Ua2ZOBCiGRL7wTtuvKEdd+54h6OVjaCgxPsQocqKgD3gmM9MTVH/mU3Pevuo1zmxArWaS1POrn90mXBHoQwtbKmURiRYmGlwa0CRGFMINYwQi9HxnR6UdPTwEaOSAKrOzkFzoizl24IDmTxjedKKXjgZkAkhdWDZqs6j7FYN50p7mG9p7eoAOEXGdU0PDHD51wp66P3Eu2c9no3wU6/z6ohj3uJ8htesBOtvxZ7cOGd6kEGPuDzUFd3H93JLWGDAMdYRCai83KP47Ozs/TIUSsstWKBjYbHTnfzSphr8Xx9f5C1RoWDTPuDA09fvO6MyDx6xsX6z5LGTuLXt3PCRh/rJVjawbEp+vf0arbAEgBEGzcqBlgMzxX30r/GlilpLZGNgbGAiHuXl+hPKgeLTA5E+e24Moq5+oR8y0s0OjlDy54lBg+ldbJYidtgEsVlj5vFGk62alAUlyevCKBWUFvHc5qdm+NrWJQVhgEmN799wIaE1Z3FRvuOZDsjEjOOuHjASEmc5j0sU1JXwYCE5b6wJEK0jNsdwi1Jq6R3Ex30yalG8vvcVN0xRm9Z7fQhgFF0HXTeu4l22nCqkQJ+D50r6lESssoLSBW5wr8creeo5kp5Hz0dcIpsDQNmBE3fHoCLXF/hI6H7hFsDR9xBxeXVNDr2isUd5xpdLAFgQXE5bZKJVms6WdMOOSP2JO13ce0x0vZR8VReWRsWwHWRzjg86Z1QIpNKBuPb2kE2IJ+cauCQT+/vASRELBDTgdEpqu4YVfOHIjQUCYbfZtWwnj5b1E1JN9p1cXLoFy0Nw+zsHD2y1yhiLCwzPiPnqRrOIPdKxMX2qlpVhHfEZ9Aua4YzIjo+XQUQCYTq+sbXIsLyDcI1AYjRl1sYlP/IqOJUf2P3KxEv61wcCR6MTOa9TvIsQw8O82CT/hyRoaljZ/orex/9JMkhRJmzNcFVDZLAgVPT01RUWqm4P5ID7VRUVk1j4xMs5tx+k07HoFPd42bGCFYY3kq0Jc0ZscOa7kIFPAD8nDMwLUr+L7gBfw+xS+NzU+mTEfqXPaX06ekm5r5Thc+FcVFdFCXhmmDn3CDnDAMeir7UwkDrfUkkZf92soHVw+mH3fRPUcVsiESIqDw3RFvAYajC4kRDUYUW8ukscUdXD1txQx/gC/p81Nis+IIWG88ciLTYJIB72YhoAIYetgwlGmshZFAgbn84WMvxLMCxXHuipK5k1sXBFjgSvyNhsLhAR3OfqdGMJPYjrXay3X7KRmj3lVb6QUwZ/c/Reh6gh1vEbVVET7YBqS/0qbzysc4KK/4g7wWAd/MecemxMbwTpSANTa3MgcAK40aRsTZnxM6EDBZhpK0/i4qnmvrGkFEINyoEqOHIEKYpLs35kj7adgFVXMsMFIMj3ZNUB3NkdlEPD0htOd9MP4qVKTEFQCVL/bbVzo72zNw8D8zDwuNlwO1BGAkdJvxAkXgA56GeuuZxi+C+El3IVyKMCBMSEoWKH6gALvsApqqtb1Jzgzvj91J0XLozIiYly7XDmkGR0ohU1L4WHWgmcMbI5AwdzuvmEo+Yq61sHKT4Yo8IZf/dLgZ4w+kGekdmpxWQYWxghDafb+Jz7lQNsF4FqBDzzecaye9109DQMIsiMjaoHGvv7OboJLdQRCIaeMIaI0p5+KiKctmYKJGIIQuvGREZDyP9tzthrzMied9RV6RSSY8f2Y0J+NfIbWs5RxD0iMe9QBNTswzgoZwuRQcqyQKk75Mc9LsDdXx+UfMwvamIuBBdoR8B9LNhFzvLSL7yMVslJx5Q8VD/fIIWZqfU1JXc651n6Tiz+1JWTeOvJmhqaprGxl8p4yfB0gZM8ovKhB+ojJfHpx9yRmQdOyscaSRS2ZHORa41CIDvRppPBX0IHVfUNCz8O8U4yKwNIo/bVQPk87rpz8hOK2EgRBTnVHaMse47nPuMfUu9+wNrjTQafke+DsDJBIOaleHP4juyMQgFUeeDFwJxZ/B0XoRsOwBEdavkQKi8/UeznRFnL99wbVEG0ZGJwQQWn89nYOHXS2LcAvUyfzxUywCxnlOsMdL3fz3xmC0wXJR/jn7EoG4628RpLoCPpGr05VbNvVGu/SlSYCkV1DMyTdOuSc7KGNJbSgJBinFOYRk1NLcbxkVAZv2NPcLb0xeucbgrkgmplI1Q7m5ekUtO2uNkQtYJDvLFeIC589+NNO8eOTYPJw1EnKxFGTAqMBIV7aPcjuSbT+lu7ZDgXB4KEAnbCl2+kUM8RU9CJx558Iy5sLq+mXILyqmQAXNQTqGd0/kiAoEIV7DhgAiHG6HD82RiJf3gSR4bgRUGVt/mPnRG1De2uORAOlI1O60ZrHxhxcx6wHxj87H1EEKvobEp+kU60veKGCsgvB1vp8gLLaJm0O/mPQDkZ6JAUzFKn2Y3sN5TDY0yDPrr/bU0Ob1AYyMjyuCSyLrUNbRytga5Qc4lPrTz0Ocwj4kEVz/Iz8BiZGQMRkMdN9q2J5XqGpq1hCrKWoUvmMAF46/TmVbJrJj9bkq/08FcKN0VrmBQ4t2mnvGQw6AcYwfcdL9uiMVbujfiJaAkpJyulKEkzUPllfUMUt/ACx61Q/Z5YHBYdV8wDy8c9wmaJ7/Py8ObMgrZFpvKExlfDI84I5aXPa59R84ohTQYkbPSLU7pf9d42DzCFcy10GVP+iZFnAwu1EUbEEWtLkZ3H2WPfOP07Dz96ZAYBtVARPmInR3rRYze9fSzMUESAaEf2gBjgSlnyEDrZxWEVll4WSKlzyNzSkofmHFKXx1UQo2wUmS970i2Yaw0+KZmWss5wefJOHknDIKMSmRdDKfvK2lg1EU+j7FiFYR2wdCcZz2qGRPJwdCPtV3j7NKgMkEDSewBplbREL79PBa9tET7j2TTFztFGAdL/JUcVBLDmk/VLANEGToRQ3kY1gzXeQMxd4U4vgZCnGxve0nvWMuUaKNK5aQ3YvV1McHXinzjNP1qL/KNwprLzM4bsaV0ubSXr0Ui1XytRuH7BXAxrIlpt2Lit0jngxMbW9o0AOfmFzi2kxOiUVR+L69YHZkL1fj1U+g3DeMAg4DUlqiLUYZBOX0vstOiLkacj06pcS640OumPVfb1LQYp/4R1UhrrJbGBT975eMKl5OfcgtKVAcaRiQ6Pp2AGQOolnacvyoCZeT7dyVxaQcaaC7teD1gaiRFkQegFJdGcJHmWH+j1MUweCYCQEk32+lN0wgewsKjed1BOtRIuuNB/YLTL9QYxkJksSVmoZ44d1WUduirs5DrEl62Ml01ykqPVyguep0Eg+CanqXfZQnHWm9MkKH56/HH7HzjPD14+I7r/3K0jlNcwo+UZXFldLW8X8eBICOQZmaQ+lES+o4UlrS+LL7bYqm6HrG4nCeicCCUZZxa3obkagLPk0CYE36E7vWQdKyzi7rpR7GlqiGR3ISyjuyHGKnzsE+IxCmMD75fKOljgyG4T+hP6FIAX905xpkd8/O05xo9BTNxeduZS6Loip3nJIpDedtCiPI2bCge1BdYYgjvSXsnp3LMN3/dJAegYHk/TBG6UI2TUxzsMKd800HNvRM0/GqaOgYnKfPeM3ZhDC6Q4kP+6XAtD6sir2h+VmgyAskFlk+7GAOZK0Dh/Z3cQglXMICTTqcyNV5X4nvqglJkuZKzuR4K/8ahC/ff7aQfxmrVWXIv84DwGX+5t5o+TMHonqxBVIo5FRB/GFtOX5YICxzK/1yRlDAW1heTsWUClSMQSxqP/GkAmibaYLv5bS4XEYqUDXKEVqqqbeTfgh72mmnZs0gjE9P0633VLIIoSBLTILRSYQAFl0WWzklRl4YH4o4sDiphUV5ifoaZzJlrYdT8VFPfpOo+4ZlYOBsjsApRZC4BdLlcHA/LUl8UHUE3wpNHKGRuwOskaVWrOsbovSQxg8lcJyiB1Kex2IHGkGmCnQelIOZIPCAZYX6GkYJ/R/Z6amqK4tMOsc4DeJhQjrIOTPVAhGacqeTz6ibaiB8KS8q5oJpnL1rT6dNIK1366jb7RN+3QQFBlO3tI6wPOeOsACQzLhqIYv9hKuJfO/1qXzXVdo3xS1iX2Bqe7afLX3+rFFSKWVrAIr+4XOE+00Qb82xNMdXLQ7bME/SFMtVLpPshypgv8v2LMggg9Lx00a4rLcxZAPLd+HLOWiPjAl2Iyi+EceBU69ftNDg+zVZ6fm5l6xqK85j7KUC1j4XobrdodsCWdYI8vLyKeaqXYaaScaYmlir5IlpaIDHZEKWtA4NDPD6wcgO/O+H+KHVDxVZD9zgPAXx2ppH+60Ad/Sazlv54qI6+ONdExwu6qbVvkkXWh6JNQwJjbW3kZ/l8PMkag0WYmcRZl5gUBlCuMSPBM4iwfqaSfsI1Nqyrohdl3AzTXTEdDMU2a23g+kncF/dHwgHgyKFOhHUYRHdOz7GRwPHAsjazM9R9ViJcA38PYyJYSkpGYzwvZGusGtLqwQsjwsap/uAyn98nZnNHYja3ZpWzjp3jBxsmXAeFQq+foH8BmiRztf96CddBXWEgHX0S6SoBHvqMmUrAwDjhek0Aaidhgp0lJUtMRFam/CPZgClg8Jnw9kRIpHBNiIaGpe8F9LWBqWcARFwbtoswlvXezkSOOLTJhcGLT2gAmuYLG0n4O/0DQ+pSdbxiB7zybRY6cPwcT2BB9pr9qXU6rXKyjjkm/W4U/vmybVgmCn1DWe/BE19qnIc5MrzoRCqXwRnBC2auEPOFQxM2zBvbysuCiGpW4VzG8dIhGEPBJhoYvgOhSAK/1uv03L5ekgDCHUP1AawrwJPOMvq2ZVcitXVgcN9sF0IBGMKNCSbNMje3tnOqCw8Sa1CJii7kEjFmIBfeMTdc0Cqd/i6cuBLnq/cUqXy0EfNidifu0wyGwnnIOOO38HgYjewaOdB4UdvTTmZxBNnqWiu7k7gxqOBER7AcnVjDJUSHgihMx9dM8nrtPubJMiBR7zPP4z2f7xQLkUlHGd+RTG5t71wBvGAsQq6ZEJ6EkcGGxRksKZm8kJd4g2KBBuhFJGJbnjw1LD62NpDCnxOWu8IQzhckFh9DdIGsEkSW1zhUkiUyPY9QFXXR4XEIZ0SCFt4xXxiKBIiYeIxVf+AnRsaIIVEeFo1OYMKKkkIRB3gpOkyMMXfUSKuAtAbx1oAWi+oAuIHBF3T+yk1uk6gqEMABRLT94InzSoxr1nkrkwAwyI0xnxjs2uhv4PV5ebjvix0CNOmA8rqmkXHcSF6AsbsXK52x8pY1yMGkdX69HCeJFxeD/+r1UndvH126fkdk17HknVzjUPeSb+cUcBlLeM4LTyEAlIDp9yuT3GC1kvYeoU+2xhiWAJXLHsPwyCVAMUcXYRPGWlfPM64MppiaLzgN95ycdHK8joUhYeiQBIFqkQvpoG1QM/AcMFVWbsH9NX8PJgGgeeGdFSncTcUbXHIv0f28IjEZT78IrcKRMDIAc0/SfjqDRWgdYhFaDDmCY3g91oBf1Z1iEVrM/5WL0C7z4mg4B+DjmrnZOfZRURh/5tINik3JUlf0FUOQaZwIwWdevsqSxuGpWAYPtzL3BYsPhZI68/ewHGim4AuDCecAALGhxu7K13f4bQNI5NIEkGJQBt/RSfa/Ym3MDafOX2PriCWOG5vbqLPrOfX09nPiAjqsr3+Aup51U1NLG5VV1NLtnEKe9JKSeVw1BFiBDUkAaRzkswAckgJXbnxLo+MTajuD+7E+WiOA6ye5YbGHr27d54IcrL+F+mvmSqVzIF6PcFcSDxUyCLzAdjwfw+KxOFdwcCpng6C3JPjgaLhPqFOR95OE82Bt4euhggDFQ2sFTlviWX9MLFQrFmQThG2NfuB6SONYuSHL8chexRabuXIbVjWPFymjEJ1nYFEFgAnOManMPfyZVzUPJgFuMtd3i6XgU3ldQzwTz5ZbuHauRjJ1h7BP6mt8h/HhKf9+v/8f9mcE4xOTVF5VR+eu3KSkvUeZu1CbCIXPnMTLiuIPCQRh9oD8zGTNoCiLWIEX1+DaHZZ0SsafEVy+SfYqGClt0Od1bW63yNhAd6LQAABi8/v9c+DAEH+HEf5vIYC62PvVz+bfgsnrDJj+DmN2dtbZ+azbWVRawX9tkXnsrDPOdsAZFZfm3B6TKijW5sRUAhA+oyoe06vw1xn4Cw3xdxg9fC/j32GEb/9qhGvN/RB/5YH+aiT/DuP/AU0T3/C2PEW4AAAAAElFTkSuQmCC",
+
     "version": "1.1.1",
+
     "updated": "2026-06-08T04:55:13Z",
+
     "home": "https://github.com/SaXz2/orca-link_icons-plugin",
+
     "zip": "https://github.com/SaXz2/orca-link_icons-plugin/releases/download/v1.1.1/orca-link-icons-plugin-v1.1.1.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "链接图标增强",
+
         "description": "自动为虎鲸笔记中的链接获取并显示网站图标，支持多源获取和本地缓存。",
+
         "category": "可视化"
+
       }
+
     }
+
   },
+
   {
+
     "author": "SaXz2",
+
     "id": "page-display",
+
     "name": "Page Display",
+
     "description": "A page space display plugin for Orca Note with block type icons, multi-row/column layout, and global search.",
+
     "category": "Visualization",
+
     "icon_svg": "<svg width=\"64\" height=\"64\" viewBox=\"0 0 64 64\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><circle cx=\"32\" cy=\"32\" r=\"30\" fill=\"#4A90E2\" stroke=\"#2E5BBA\" stroke-width=\"2\"/><rect x=\"18\" y=\"14\" width=\"28\" height=\"36\" rx=\"2\" fill=\"white\" stroke=\"#2E5BBA\" stroke-width=\"1.5\"/><line x1=\"22\" y1=\"22\" x2=\"42\" y2=\"22\" stroke=\"#2E5BBA\" stroke-width=\"1.5\" stroke-linecap=\"round\"/><line x1=\"22\" y1=\"26\" x2=\"38\" y2=\"26\" stroke=\"#2E5BBA\" stroke-width=\"1.5\" stroke-linecap=\"round\"/><line x1=\"22\" y1=\"30\" x2=\"40\" y2=\"30\" stroke=\"#2E5BBA\" stroke-width=\"1.5\" stroke-linecap=\"round\"/><line x1=\"22\" y1=\"34\" x2=\"36\" y2=\"34\" stroke=\"#2E5BBA\" stroke-width=\"1.5\" stroke-linecap=\"round\"/><line x1=\"22\" y1=\"38\" x2=\"42\" y2=\"38\" stroke=\"#2E5BBA\" stroke-width=\"1.5\" stroke-linecap=\"round\"/><line x1=\"22\" y1=\"42\" x2=\"34\" y2=\"42\" stroke=\"#2E5BBA\" stroke-width=\"1.5\" stroke-linecap=\"round\"/><path d=\"M46 20 Q50 20 50 24 Q50 28 46 28\" stroke=\"white\" stroke-width=\"2.5\" fill=\"none\" stroke-linecap=\"round\"/><path d=\"M46 36 Q50 36 50 40 Q50 44 46 44\" stroke=\"white\" stroke-width=\"2.5\" fill=\"none\" stroke-linecap=\"round\"/><rect x=\"48\" y=\"22\" width=\"10\" height=\"6\" rx=\"1\" fill=\"white\" stroke=\"#2E5BBA\" stroke-width=\"1\"/><rect x=\"48\" y=\"38\" width=\"10\" height=\"6\" rx=\"1\" fill=\"white\" stroke=\"#2E5BBA\" stroke-width=\"1\"/><line x1=\"50\" y1=\"24\" x2=\"56\" y2=\"24\" stroke=\"#2E5BBA\" stroke-width=\"1\" stroke-linecap=\"round\"/><line x1=\"50\" y1=\"26\" x2=\"54\" y2=\"26\" stroke=\"#2E5BBA\" stroke-width=\"1\" stroke-linecap=\"round\"/><line x1=\"50\" y1=\"40\" x2=\"56\" y2=\"40\" stroke=\"#2E5BBA\" stroke-width=\"1\" stroke-linecap=\"round\"/><line x1=\"50\" y1=\"42\" x2=\"54\" y2=\"42\" stroke=\"#2E5BBA\" stroke-width=\"1\" stroke-linecap=\"round\"/><rect x=\"8\" y=\"18\" width=\"8\" height=\"4\" rx=\"1\" fill=\"#FF6B6B\" stroke=\"#D63031\" stroke-width=\"1\"/><text x=\"12\" y=\"21\" font-family=\"Arial, sans-serif\" font-size=\"3\" fill=\"white\" text-anchor=\"middle\">#</text><path d=\"M12 32 L16 32\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\"/><path d=\"M14 30 L16 32 L14 34\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\" fill=\"none\"/></svg>",
+
     "version": "1.3.0",
+
     "updated": "2026-03-20T07:31:26Z",
+
     "home": "https://github.com/SaXz2/orca-page-display-plugins",
+
     "zip": "https://github.com/SaXz2/orca-page-display-plugins/releases/download/v1.3.0/orca-page-display-plugin-1.3.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "页面空间",
+
         "description": "为虎鲸笔记提供页面空间显示功能，支持块类型图标切换、多行多列显示及全局搜索。",
+
         "category": "可视化"
+
       }
+
     }
+
   },
+
   {
+
     "author": "SaXz2",
+
     "id": "snippets",
+
     "name": "Snippets",
+
     "description": "A CSS and JavaScript snippet manager for Orca Note with syntax highlighting, search, import/export, global toggles, single-snippet export, and safer JS cleanup.",
+
     "category": "Editing",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 32 32\" width=\"32\" height=\"32\"><path d=\"M9.5 8.917c-0.391 0-0.745 0.159-1.002 0.415l-5.667 5.667c-0.256 0.256-0.415 0.611-0.415 1.002s0.158 0.745 0.415 1.002l5.667 5.667c0.256 0.256 0.611 0.415 1.002 0.415s0.745-0.159 1.002-0.415v0c0.256-0.256 0.415-0.61 0.415-1.002s-0.159-0.745-0.415-1.002l-4.665-4.665 4.665-4.665c0.256-0.256 0.415-0.611 0.415-1.002s-0.159-0.745-0.415-1.002v0c-0.256-0.256-0.61-0.415-1.002-0.415v0z\" fill=\"currentColor\"/><path d=\"M22.5 8.917c-0.391 0-0.745 0.159-1.002 0.415v0c-0.256 0.256-0.415 0.611-0.415 1.002s0.159 0.745 0.415 1.002l4.665 4.665-4.665 4.665c-0.256 0.256-0.415 0.61-0.415 1.002s0.159 0.745 0.415 1.002v0c0.256 0.256 0.61 0.415 1.002 0.415s0.745-0.159 1.002-0.415l5.667-5.667c0.256-0.256 0.415-0.611 0.415-1.002s-0.158-0.745-0.415-1.002l-5.667-5.667c-0.256-0.256-0.611-0.415-1.002-0.415v0z\" fill=\"currentColor\"/><path d=\"M19.965 3.314c-0.127-0.041-0.273-0.065-0.424-0.065-0.632 0-1.167 0.413-1.35 0.985l-0.003 0.010-7.083 22.667c-0.041 0.127-0.065 0.273-0.065 0.424 0 0.632 0.413 1.167 0.985 1.35l0.010 0.003c0.127 0.041 0.273 0.065 0.424 0.065 0.632 0 1.167-0.413 1.35-0.985l0.003-0.010 7.083-22.667c0.041-0.127 0.065-0.273 0.065-0.424 0-0.632-0.413-1.167-0.985-1.35l-0.010-0.003z\" fill=\"currentColor\"/></svg>",
+
     "version": "1.0.3",
+
     "updated": "2026-06-08T04:54:22Z",
+
     "home": "https://github.com/SaXz2/orca-snippets-plugin",
+
     "zip": "https://github.com/SaXz2/orca-snippets-plugin/releases/download/v1.0.3/orca-snippets-plugin.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "代码片段管理器",
+
         "description": "一个为 Orca Note 设计的 CSS 和 JavaScript 代码片段管理插件，支持语法高亮、搜索、导入导出、总开关、单条导出和更安全的 JS 清理。",
+
         "category": "编辑工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "SaXz2",
+
     "id": "tabs",
+
     "name": "Tabs",
+
     "description": "Adds browser-style tab management to Orca Note with multi-panel support, workspaces, drag-and-drop sorting, and recently closed tabs.",
+
     "category": "Visualization",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAABpmSURBVHhevZ15dFXVvcdjR322dvjj/fG6VvveWu/1tautHURmkhCSkIEwBLTt0iUogwgBSqmg1NcKaolj69TWUmtbQVGrpYLaMiRgu1olCQmQhBBD5unemzm5yc2dvm/9fvvsc35n33MvQbt61/quvc+e9+f89nD2OYE0v787H7FIqd/fW9rn72X3n6m+XiUz3EtTSZsqDbU/WVwq6X5fbv+JW1rA3/skAMSiYcSjYcSik4i7pMLdYU54qvQUh4gSX1tuUn8kDER0XWEOl+lIFO+kMfM7daWWu42p+qK4yDROOvqlEXUK9Pt60NfbA7+vCwFfF/p6tSi8G309nSJMhQd83SKtju+28nTB7+tEwJXHQz2On8rzc35VVsCqk127foonmeFO+sS2ijiW0yfuL8VTe61ylVTbFRedpweB3m7OQ2EEUQCkxEbnPBrhbojqjAwL9GhJCA5URw4Qnd4sX5bhrlfHeYWlSp+8L2a8He6KU/1QYLvYEtNoLBNJfRdSWYxZiQlKyswj07rlWJNXfhlnpkssKzWYVOUkK88rjvOxBYYdgDyUevTwEEMkRYFejZDXTlrz2huYee0lM42X30uybrM8s2wzjSN3vAugsj43wGQFm40yG2rmvVQeL5nlXE6+VH4zLFW4jDPrp2sbII1lv20liY1PVags2Lw2ZeaVYWaZZlnJyk0Wbsqrbi+lqt8UA6RFhDxmIicjuc5ETyuXV9pklZkNlGnM9GaaZHHmdbKwqcjM59Uu2UcpYw50F+IuWG03aJj7xDxgpjUrlw1LpsS6EuPNMG9RukQYZv6pXKfqh44n0f7TssBJV0aZyMzsTxJn6nLjzetkYV5y0l1eelm+7HOq/sl41xCWm1czoawwWcGyQWY5ZplmeLK8ZpxS8nQBvw/+vv7EcA+ZfTHbZvq95F6FPRs7tcKTVZSqzPevxI03y+dDoK0Rgdq/wz8waG+Ak8lsn+yH6SaTew6cAhSzYtUR50nEzGM2WjbYDEulxDqNNDS19A1g7PFiRFd/HENvPgH/aOiyIJoy+2z6SfwoJwHKRGYlehPpjk8EZV6n0lTTXjIdPZ/29iB073XA2isQW/cxDL71ZEqIEkSqa1m/2Y4EC0wmlYFcs5LEQt3Xjl+Fe3fmfYvK9PUgEPDD3z+A0ANzgPUfA0o+gei6j2LwzdQQpyKv/mklWKDMIF1lfTqjd+FmRUryOZdcNdzfv7oQCATgHxqFfzgIf/8gh/k7W+G7WIfQj64F7rgS2PwZoOSTbIlDbz11SYiX7kdiuAIYIoDdpeSRZE3pDOazYCq/WZkZZipZGrU/7YJ/YBj+oXEEmuswWP5bjP5uE4KP5iO0axrCO7+M8J2fR2zTpxEneFoblSUOeQxnWZ93XxP9ZtqEISwL9irUy5Uy06dKOyV1dyDQ1w//0Bj6Th/F6DMrEd72OcTXfhhYnQas+7CyuA3/Bmy82gFn67NAydWIsiVqiKlHgey32ReX9BxIR+B0imsmkBnNCpTbiZH+AIJDAwgO9WN8uB/j2h0esNRvxUm/cpNpdCCAfprX6LBzeBz+i3UY+8XNiK2/CliTxlZFcJSlfVr4ExXf/GnEt3wW2EjDWVuidXDiAUb2z7vP7vT2HAhjFb6UhgK9mBgewPm6Wpw4UY7y8nKUnyjHiZNaJ5ROGBJhnJ7zONflJ8pQVVWJPn8vBoIR9L+9H6Ftn1PWtulTCYAYkjVsNUQJU4YriB9REAdHEvokQXlJH/xKmAlDWBZgFqavh/v86O1qx+7SUmQXL8esvHzMzivAnLxCzMlfhNnk5hXarikZL9PoMjKKluE7W3bg/G92ILbxKjVEyYo84NmgtlhKAtFOS3Pimg+h/+R++AeHPSC5rdDNINFS3SfSHiZqQuz3dWGoz4etd9+Nb2Rm4fqcXMzOL8DcwkUJmkduQWFCeIJEGirrq3nLcO+N0xBc9yFg0zVqHvOAZfqRBKBLJdcgdmsaBo4+wyu5CdCE6c1Bh8k5MJwI0CyQNDEyiNcPv47rsrIxt2ARHvzZT1F99izOnavBWZfOGG4yUbxKQ2VU1jfgpcd2YOL2jwObCZ4bnIRGihmWl1IEb00aBl++B76Bocvak0oe0gIThnDKjD2dmBwbxgOPPIxr0zNx09p16pUl/2L/BAGYHAEe+CawgQB6QCDRXEgrLm2YaRVee4USWywtGl55rkFsdRoGX/ohfCMTavPtAUr2W4LyiiMLdA1h56ki0XS1PzQ6iHtL9+Br89KxafsOIB5BNBREZGLMdklhy52yQkGEAYR+sw7x29K857w7rkR8TRqiG65GZPt/IfTAbIw/vgTBX9yE8b2rEXz624hu/XfE5WJDMAkeW97/WfB6E4CZSmZxboAeFqjJmpm0nwDuYoAZ2HjnnUA05AL3vgVgvL4ckXX0GCaG7iaC8Elg89WI3z8dQy//EP2Vf0agtQF+Xy98g8PwDY7CPzKO3qExjN83E1ivrJeHtQ3vHvhGxi3L63D1y0te/Tfh0YhkC3SO9J0NpglOZejCBAMsVQB/sB20/ZEALx9mEJFQCJOxGCZ+tghYc4XVedq7fQKRNVeges1/4PvFM/HKHw8iDmB4bBwD/X0YCPgwEOjFoL8HgwEf+vsCmHhgNg9tBe9TPMRHX/sx+oJhDPb5McBpe9nVovzkBsQjqgnN9GsmnueByTKRFMA9+NrcdMsC3QAvVzTUw/E4Ji78HdHbr1SrLg3f2z+GSMlnEHzrUdy8cQu+mFWIBcU34Lnnn0fTew3oam9BZ1uzo/Y2tHe0IXjfDDV/bvkUsOFK9OzbifbAMMe70re1oLNV+Ttam9HV0YrgyACG+/3w09OPh9W5wqxw+iDBfisnE3plcgGcRwB/AMQ+GECGCGBi/xZn7lv3EYS2fR7j9Sd5XTlbX4+c4mJ8a/4CTM9ZiLwbv40Vq27FipWrsNzSspW3Ysktt6J10xeArZ8Atl6DJ1Zej4LVJShedRuKb1mJ5bescuWx896yEituWYWdu3ej8UI9xgb7EvqdjAcfJjiPcpfOoObA5EM4tSidkTY8icmxIUze8xW1SNz+UYTu/E+E2mt5XoyExhjihcYLWL9tG2bn5eObmVn4enomvp4xn91vpM/HtRnz8T/zsrF3+RfQftuHsWvpl/DfmQW4NkOnzcS1pHTLzbDyZ8znMLo535qfhZvWrUN3RysPaxOgdJW/k/tvAVSvNU14JsRLzYGpRenGXRDDcajhe8dViG+4CuGSz2L8vXcVvHGdb1Rtc6KTqK45jZdffRXP7duH5/bvw2/377dE1y/g2X0v4JUXn8Mvn38Rz1nhKv4FO50jlff3Bw7gx3tKkblkKYPcd+AAQqO0T3QbjwmTRF+TJcyBGqCUDg+NDWHXgwTwgwxhgmj5afiW/ZKHb3T1FRgvf5aHtI6fDI0hHFL+2GTQ2S/+s3+xKG5et54tc88jj/F+12RhQiTxYUIfnwdOJCTyIs4WSADnpmPDD1IB1NZmhrvF89/zm4BlaQg9WojJOO3Nk+cjoGbYB1VschzxSAhrNm/BtfMy8JOHH3FZoGlEkgdNfZYFqgPVVJnc25h0bEwJcIqKRRH8x0uYuHcOJlqrEYnHrbjkEBN1OfW7pxASAYyGx3Hbpk08Ne155FGel5MZlJQA6HyZYFI2LXC3HsIE8LLmQC+NIhyN8j6QXBXmsdh4hsk4MyyZEsuRAGlBIYBsgR4M3Fz0YYK1kVbgvK1PArQtkObAKQB0HutkOiNP6FIWN7Up4f3IBdCyQAIoP3WRICWbJI9ybsnMvIhMYQhHecK/jF88gsj4qCiD8tNzh52Aw81n7DCt0Na3yt6/GOLhiYT2STHASW2BGfiJtkAPYDYLCVDvA2WiZK7eB36VAdI2JpwAkBozNjSA8pMncKz8OI6fKEMZqew4ysvLbFEYxf3l2BHU159DVHeUyguH8M47/8DRsmM4UnYM71a8i1gkZK/IBJIXlPAEWlub8JejR7gsrbLyMpw8eQK1tecwydsgYFJYuZ3fBMiLiAPQtD7pV+9E9LOw8U7EzKjD3IsIPcoRQPcdRiyMjrYWzM0rwHULsjEjd6FSjuPO1GG5C/HlmbNx/8OPcCc5fzyCtpYWzMkvwLQFOVxGZtES9HR1ctmuugDsP3AAX5oxyy6Pnlam5+Synw5rb1p3O97+699U+R6jxZwDpQWaMg1KHGfpOdAbohYVbG+krX2gue2gTra3NWNWbh6+lbmAIZAyFy/BgmXFrJkL83F9VjauX5CLL06fifsefJA7SJZBvxdeepnBzV+6DFlLl2Hagmy8evCgBdmBQL+XX30N12fn8uuF+UuWYl7BIqQXFvErglkL1euGWTkLcaqyAojH3hdAk4m2wIQjfZnYhEjX2gLVENYAnQ6FJ4KITk5gZLAPf3rjMA4eOoSDbxzGobfews3r1/OxfXrRYvx8769x6K0/40+HD/Mpy+nTVYiFQ1xWPBZh66bO5xQvZzAzF+Zhy907gXgUMR6Kqk4JkG7YvXtKcb6hAefOncGpqtO4a/duzCko5PitO+9BPB7znHLMRYS2MabxmEzEKqxerMuEXiAT9oG8CrvPA2meIYh0V83f1rt38rCak1+ICw31RmyUFxGykIvNTWxJM3Lz+AH/rl27MD13IVtue2srPzXo/Rz9GOCCHNbTe39llaeeWPy+buQsX87vWr67Zi1CZHHmokIjyMMCTQPygukC6IJlmKv2208iDPBOtkB6xDKHhesOh4I8rDdv38GWRO9SqqpPcwf1oqBFv+cPvMjDl4b98bLjOHL8KA/haVnZOPDKHziNTE/Pxhrgz3+91wKofhcvNiFryVJMy87Fhm3buMOmBaYawl48EgDycRYtIh5WZ0oOYX6U81hETDHAeEQALERVTZW9NbHT0fCNhrF+6/fZUsni6GvYnp4OZC0t5sWHV/5YBDELggJIQzgHc/IKsONHP0bZ23/FsbLjOHj4DawqKWGLn5mzEEePH+c6za1Qsn2gCcsF0Ap3f1zkAczM6D6N0QDHLUvytkTTAmlOqqxOBEjD7sJ7DcgoKuLhW3Lndp7z4vEoz4kzFubx0G6+2MThDkBlgTRXzisswnVZtHBl47r5C7gu0rO//R2npeOxZABXb96cYIHq/ZD7UxBplc42xlqFZSIv8hMjA86BqniUU3sq7ycFAox4GJt3EMB87pAewm6AwG/27eNXpgTk9TfetIfiwcOHFJSsBXj+xRc5TK/YGiBZLC06eTfciLwbvo2c4hWYmZuH9EWL+QD27b/RVsZ902yAvA/czGeHJkBHiQbmfpQz4HlRp/fC9hzIq7BaOc1GuQFO8LBTAK0hbACkeZSmEToRoS8daMvz9N5f49VDh/DaoUN4au9eZCxewnHrtm7l7QNN/grgazxf0hDf89hj8Pn96OxsQ0dHO17546vIWbacrTe3eAW6uzq4094Ap76IuAGKF+uXkmsIT/GdiD2Ed9wlALqHMA3JhvN1bC2071N7xTy2OJKeE2lfSJvqxgsXeMXWAHkRyc7BU796RplsjE8V2XvfQw/z5poOS197/U+uG5cKoNl3L9FBtPo+MKLOA5MNXdsC7Xci1kZ6qgBpCG+XACvdAAHs/d1zvNJmLVvGG+HMRUuUipYgY9ESZBQuZog0lJ/9/e8VKLGIkBWa2xj6/fD++/kGuIa/WP1jkxO8d12tn4Vd54HU7+Sfw5HhWR9YJv9K34baY70X5iFMi8jlWSC9iOdFJF9boLIEZQEh3FqyiZ8aMooW48ixY2hsbERdXS3q62rZf+T4McwvWsLvRW4r2cR5NECCN2thHr/0r29owNmzZ1FdU4Nnnn0WmYuX8uIzfUEO3jl1Sq3EAiBZn7MPdANUfU9cRLTEHKgPE9wQJcypvBf2krbATTt28OpqLiJkLbW1Z9gyCeAtd9zBQ1r9yNX+GFbdsQGz8vN5ta2rrXUBzF5WjKzFS5FOTzuFRfylFz0TpxcV8fbk7l27EI1G2Npc7ZMAxYm010g0Ibo/7TA+CDcz0/V4wjZmqgAjWLt5C74yZx6vdKeqaAhrgMCjTzzJBwJ0sPC0NY/JMvSKS0P0SzNn439nzMYjjz/BYfsPvMTXdHPoiUUfJpDI4vNW3IhHn3wKweAIvwQyt1t6CCfbB8r+S9f4e2HnywQTnBSvwqUPOgDpScQDoDwuYoiT46iqqsLRsuM4Wl6GQMCHKD37Unx4AhWVpziOnjp83Z3O0ZbRUX9PF44cP46jZWV8OECvRdtbm3l40/FZ+cmTKDt5gkUfbtIxmK+nSxlwRNUXFe0jJRxneTyJmBC1jI+LUi8gDDBhFZ7qtzHWq0nrR4ecYeu1JR+K2sOURm/IOFy1RM/KUTXvqV9UWWbKA1WqlkaJ2R5LGmCKJ5FUclmg+deaZmJSaEwtIlRR8hNpujbDrM84zA54aCppPqi4LSFlje5n4akB1IbmepTz+vDazOh8maC/jfGyQLp2n/6aHfBSYjmpNdVyZTrtVwBVfQlH+uJE2ouB5OO2QAOa9icdwkkt0C375bj9yOfWpfJ7icrzKoskyzPTyRf1WjbAErcFyk9dvERcxOdtU38SuXfPT/jFOm1LaLefCkCyTv7LRG1L0Qa9iNBIWrtlCwN8wNgHmgx0OJ9IO39w7f1tjCl6K3ffQw/xxzo3rbkdiKjHJfUGTUv/ZNi/WpdTPzARHMGKlSvxjYz5eOhnP8Vk0Pm0Q3KRfGyAcgi7EpirsfUk8oc/vsZfMtFmdvdDD+GdUxWoqKhARaUhHVZxSvgrcIr85FYqUfwpQ4l5RJzIo1wVL9NXVFSyv9Jqi8prtkvF/+PUKey8bzfm5hdiWnY2Dv/5Td6umdBMl6QA9naX0jE3fVgo5etqT5CC2YXvbd+Bb2bSg342pmfnYmZOHmbl5vPxEYuuLfFbuBwVpvxaKkzJ+5ry6zDlN9N5yUyj6puRbb0RNNLTQQR9MkfD93t334VB6xtqycFko0X71bTutpZSGppdbc0J6my96PJ3tDShp6MVXa3NuL/0QeQW38B/D0LvHOgZld18ehOWj3n5hZiXV8iPaOSn15xz8wswj5SnxGGkhfkJfk5DZUjRH+PQ36VY1+laBYXIKFiEzIIidkk6PpMOJizRc3bmoiJk0ps7SlO4CFlFS/Cd29bg8aefRntLE/xd7dxXLS8WpO72Fp7SXADNjPJaA2y72Mhxw4FeNF1oQPXpSlRWvIuKU++gouJdnK6q4DBSTXUVzp6pxtmaavafqTnNomtyKay6pgo1lPZ0lcpXRf5KnKmuQg2lEelIuowzZ6pxjso+U42aM6dx7mwN6mrP4lztGdSJvz05X08HEufQUF+Lhvo69teereF8VA4dVvi7OzE2GEB3WzPam9+z+0oyGUg+DsDRRIA6syyE/FRBa9MFdmkiHRnwO39QODKA0Mggr2I0j9Df09EpNq3epKD1R4g6jRSlpzjOxxrgcPpWT4dRg8PBEQ5zZJVB/iBphNPQkwunDY7YceGxYZ7HJ6w6qb6RgQAC3Z3cHzIOcjU8ycCE6QJInTPhJStEAyTRNZlyb2ebPVfoRUfPE/Jap5OiKYHKILens9Vy21Ta7jY7n6xDlu2z5il7sRMTfb/P+Ses6Et8fa3T+rpV/QRD94sgmv03OSQApLthAmTXK6ylyVURhWkAEhD5ZRi5lE4D137dODW3XEQnyWpgd0czejpa7HlHl8eQhV/Wb4KWC6C+1nG6HVQ2tYH6lAyg5KPFADutOVCC8sokw2VFEqCGo/16stXxCeVZw6bNuiFSHc0kNZz08NL1sUvQLdCyvbI+L7hSuo3SAs0hbLIgv84jhvCQ+vsJAxQ30BJ3Rs+DBkATlB4WUpSOGqfzkqjBLY3ncfFCPbst7zWgufE8i/wtTefR0kRhDXzNU4eVt92AbkKW0m0wwep2Uf+mOoRleTQH2xaoC/MCSHdb33ENkERQZYESpG6YfQO0JVEjLWl4TRbA5sZ6XGysVwAtiK0M0IKqoXH+BlYrgRZwtQXJvnDbNUALor7W7aa+UFl8MyQ4ayqTAHWfGWB3uwJISzgXphMI14ZohdkAhQWaAO18ogFsxZZsiBoA67wDhDoj0uhrtmArvP2icimO20QWbsnVYevmUx8ZoCW7rXoOpIWRjMKCLqX7ovtL+WiFZ4BEkiswrCYpQAuCfWeN4eq6EXp7pBtjdVBbEluOhmOB4aHUpKBIi9Ud1NI3kkTl6jlTW51tCEkAkrh/FkB7VHkBFP2nxa67vdkNkApnEAZECVBD4clWWqAALu+67IDdYQ3NAqelAbEFNipL1Nc6zLRAGa87r4efbq9su5YEyX2m3YA1KvhmpMjr5G9GeHwEab3tLaXhYHKAdgFiDtQV2VZoWK8GaA5b3XlyJTwJqaXRWlAsYNovwzQ4CZzDrWGs63bdTGlNFgS7z9Z2ygugqW6yPrbAFt6oswWSRw9FDdELJsPRUMRqRWEyvZ3GkB5upqU58Kw5kBYSvTKTyG9dy7ReYFMNw1RgKE7n9YpzhbWrOZAB9na2MUBtzslkF2ZtaXiyNoawniek5ZkwGZ4x/EwYBO9iQx27FM/XFxRUmUe60ir1jZL1miBtXQKghKctmpkQwPFRGsJtpTQZuiZVYYEpAVqTtm6MDJfWJmHZWxQDlgamJcOaGurQdL7WlcbMY1oi1aXbkBKo1S9uu7BemcYLII1Yaw50AE51COt5QjbGdvVkbgxXL0vT0nCSAaJ4CVDGkSvL0lZoKhlAbXESoNlnU7YF8hBubyulkwvXquRheTpMVyYrp3B5t+y7Ky3TsAYvwKa1eoGXYSYkL1he4GQbdd9MgzChmRyIlbLAjjb+3xzU8Y84HqKjJD5OUkdK4TE6JlJHSHy0NDrIx1IqzbArrb7mcvTxFB1VWeJ/J2uwj0V/IR4c6rP+TS0dFsDYQEC5VrwT5uTTfhaVYR2rqWM0Vac6OlNtDY0MYHJ00NVGu818pKby2cdtVh67DEvEIRIc4fcp/w+NWCLYWv3RCAAAAABJRU5ErkJggg==",
+
     "version": "2.9.2",
+
     "updated": "2026-06-08T05:02:00Z",
+
     "home": "https://github.com/SaXz2/orca-tabs-plugin",
+
     "zip": "https://github.com/SaXz2/orca-tabs-plugin/releases/download/v2.9.2/orca-tabs-plugin.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "标签页管理",
+
         "description": "为虎鲸笔记提供浏览器式标签页管理，支持多面板、工作区、拖拽排序及最近关闭标签等功能。",
+
         "category": "可视化"
+
       }
+
     }
+
   },
+
   {
+
     "author": "SaXz2",
+
     "id": "tana-tag-color",
+
     "name": "Tana Tag Color",
+
     "description": "Applies Tana-style colors and icons to tagged blocks in Orca Note, with block-level color overrides and real-time updates.",
+
     "category": "Visualization",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\" width=\"100\" height=\"100\"><circle cx=\"50\" cy=\"50\" r=\"45\" fill=\"#f8f9fa\" stroke=\"#dee2e6\" stroke-width=\"2\"/><g transform=\"translate(50, 50)\"><path d=\"M -20 -15 L 15 -15 L 20 0 L 15 15 L -20 15 Z\" fill=\"#6366f1\" stroke=\"#4f46e5\" stroke-width=\"2\"/><circle cx=\"-12\" cy=\"0\" r=\"3\" fill=\"#f8f9fa\"/><circle cx=\"5\" cy=\"-5\" r=\"4\" fill=\"#f59e0b\" opacity=\"0.9\"/><circle cx=\"8\" cy=\"3\" r=\"4\" fill=\"#10b981\" opacity=\"0.9\"/><circle cx=\"2\" cy=\"8\" r=\"4\" fill=\"#ef4444\" opacity=\"0.9\"/></g><defs><radialGradient id=\"shine\" cx=\"30%\" cy=\"30%\"><stop offset=\"0%\" style=\"stop-color:#ffffff;stop-opacity:0.3\"/><stop offset=\"100%\" style=\"stop-color:#ffffff;stop-opacity:0\"/></radialGradient></defs><circle cx=\"50\" cy=\"50\" r=\"45\" fill=\"url(#shine)\" pointer-events=\"none\"/></svg>",
+
     "version": "1.2.7",
+
     "updated": "2026-06-21T00:00:00Z",
+
     "home": "https://github.com/SaXz2/orca-tana-tag-color-plugin",
+
     "zip": "https://github.com/SaXz2/orca-tana-tag-color-plugin/releases/download/v1.2.7/orca-tana-tag-color-plugin-v1.2.7.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "Tana 标签颜色",
+
         "description": "为虎鲸笔记中带标签的块应用 Tana 风格的颜色和图标样式，支持块级颜色覆盖和实时更新。",
+
         "category": "可视化"
+
       }
+
     }
+
   },
+
   {
+
     "author": "SaXz2",
+
     "id": "today",
+
     "name": "Today",
+
     "description": "Smart Today tag manager for Orca Note that automatically adds and updates date properties on blocks tagged with #Today.",
+
     "category": "Productivity",
+
     "icon_svg": "<svg width=\"64\" height=\"64\" viewBox=\"0 0 64 64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" rx=\"8\" fill=\"#4A90E2\"/><text x=\"32\" y=\"40\" font-family=\"Arial, sans-serif\" font-size=\"24\" font-weight=\"bold\" text-anchor=\"middle\" fill=\"white\">T</text></svg>",
+
     "version": "1.0.1",
+
     "updated": "2026-03-20T07:36:05Z",
+
     "home": "https://github.com/SaXz2/orca-today-plugins",
+
     "zip": "https://github.com/SaXz2/orca-today-plugins/releases/download/v1.0.1/orca-today-plugin.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "Today 标签管理",
+
         "description": "一个智能 Today 标签管理插件，自动为带有 #Today 标签的块添加和更新日期属性。",
+
         "category": "效率工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "SaXz2",
+
     "id": "video-info-extract",
+
     "name": "Video Info Extract",
+
     "description": "Extracts video information, thumbnails, and creator details from Bilibili, YouTube, and Vimeo links in Orca Note.",
+
     "category": "Integration",
+
     "icon_svg": "<svg width=\"64\" height=\"64\" viewBox=\"0 0 64 64\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><circle cx=\"32\" cy=\"32\" r=\"30\" fill=\"#00A1D6\" stroke=\"#0084B4\" stroke-width=\"2\"/><path d=\"M20 18 L20 46 L44 32 L20 18 Z\" fill=\"white\"/><path d=\"M16 16 L20 20 L16 24 L16 16 Z\" fill=\"#FF6B6B\"/><path d=\"M48 16 L52 20 L48 24 L48 16 Z\" fill=\"#4ECDC4\"/><rect x=\"18\" y=\"48\" width=\"28\" height=\"2\" rx=\"1\" fill=\"white\" opacity=\"0.8\"/><circle cx=\"32\" cy=\"32\" r=\"3\" fill=\"#00A1D6\"/></svg>",
+
     "version": "1.4.3",
+
     "updated": "2026-03-20T07:36:22Z",
+
     "home": "https://github.com/SaXz2/orca-video-info-extract-plugin",
+
     "zip": "https://github.com/SaXz2/orca-video-info-extract-plugin/releases/download/v1.4.3/orca-video-info-extract-plugin.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "视频信息提取",
+
         "description": "自动提取哔哩哔哩、YouTube 和 Vimeo 视频信息、缩略图及创作者信息，并设置为 Orca 标签属性。",
+
         "category": "集成工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "clean-editor",
+
     "name": "Clean Editor",
+
     "description": "An Orca Note plugin that hides query controls to make the interface cleaner.",
+
     "category": "Visualization",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" width=\"64\" height=\"64\"><rect x=\"8\" y=\"8\" width=\"48\" height=\"48\" rx=\"6\" fill=\"#ffffff\" stroke=\"#2d2d2d\" stroke-width=\"2.5\"/><line x1=\"8\" y1=\"20\" x2=\"56\" y2=\"20\" stroke=\"#2d2d2d\" stroke-width=\"2\"/><circle cx=\"15\" cy=\"14\" r=\"2\" fill=\"#2d2d2d\"/><circle cx=\"22\" cy=\"14\" r=\"2\" fill=\"#2d2d2d\"/><circle cx=\"29\" cy=\"14\" r=\"2\" fill=\"#2d2d2d\"/><line x1=\"16\" y1=\"28\" x2=\"48\" y2=\"28\" stroke=\"#2d2d2d\" stroke-width=\"2\" stroke-linecap=\"round\"/><line x1=\"16\" y1=\"34\" x2=\"42\" y2=\"34\" stroke=\"#2d2d2d\" stroke-width=\"2\" stroke-linecap=\"round\"/><line x1=\"16\" y1=\"40\" x2=\"48\" y2=\"40\" stroke=\"#2d2d2d\" stroke-width=\"2\" stroke-linecap=\"round\"/><line x1=\"16\" y1=\"46\" x2=\"36\" y2=\"46\" stroke=\"#2d2d2d\" stroke-width=\"2\" stroke-linecap=\"round\"/><g transform=\"translate(44, 44)\"><path d=\"M-10,-3 C-5,4 5,4 10,-3\" fill=\"none\" stroke=\"#e06050\" stroke-width=\"2.5\" stroke-linecap=\"round\"/><line x1=\"-7\" y1=\"1\" x2=\"-9\" y2=\"6\" stroke=\"#e06050\" stroke-width=\"2.5\" stroke-linecap=\"round\"/><line x1=\"-3\" y1=\"3.5\" x2=\"-3\" y2=\"8\" stroke=\"#e06050\" stroke-width=\"2.5\" stroke-linecap=\"round\"/><line x1=\"3\" y1=\"3.5\" x2=\"3\" y2=\"8\" stroke=\"#e06050\" stroke-width=\"2.5\" stroke-linecap=\"round\"/><line x1=\"7\" y1=\"1\" x2=\"9\" y2=\"6\" stroke=\"#e06050\" stroke-width=\"2.5\" stroke-linecap=\"round\"/></g></svg>",
+
     "version": "1.0.0",
+
     "updated": "2026-07-12T15:52:00Z",
+
     "home": "https://github.com/sethyuan/orca-plugin-clean-editor",
+
     "zip": "https://github.com/sethyuan/orca-plugin-clean-editor/releases/download/v1.0.0/clean-editor-v1.0.0.zip",
+
     "translations": {
+
       "zh": {
+
         "description": "隐藏查询界面以使编辑器更简洁。",
+
         "category": "可视化"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "dinox-sync",
+
     "name": "Dinox Sync",
+
     "description": "Syncs Dinox notes into Orca Note (sync into journals).",
+
     "category": "Integration",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAAe9klEQVR42syaa5BlVXXHf/917r39nOnu6ZlhmMFhYAaQAWZGRHkJahEMlCLBV0VLwViaaIwxpYnRRD4kqSRlJVZFrVT0Q75gYiWaSqx8MBgVo/LQohQNgg/ejrwVGOju6b73nr0y9t3nrNrVI6MUYM6t7rPP2nufvfZ/r/9aa+97dc11V/IruHr3z+3f5YPOzpUxO60rPbdi5TgsbTVpTjBZ4T0JCWEul/tAsoUKHsN1Xyd176q8/j5JN1fmd3QO7rkd6PMsX/rwLVfwLF2bJyqdbpYu7MjPkg+fg3c2YzbWc5ALVCMJA0xggATmQu4Y1jznsqOkFVP9kFHtr9DXbdj9gg963wIeelYA/NwXzucZvOzezSecN+zWrxrY8kWqdGJHQhJyGwEhqBByMBJyMojCcGSOEJbAyG1lCNDqZ9SvIo36pAql7g+N7tXu9u8/ebD/NSA9YwB+/MZ38wxc65bWP3aR42+vGJ7lxmRjTRW4geSGsAwgyLUKgsgA+qi9yMA5GArQNLrLHQEVToXcMvwmA3xJnr5u9D7OYP5q4Ame5qviabwG3fnq8emHXtvvLX/MLb1XxnG1pa4LhKHRpCTI6AjcMySgLCZLGqGau0Z3L+oSNG9VgyokHEld3I4T/deaDc43LS86R38f8P93AB6YWDxncfLRT3i1/AG3ejsoTyq14BSXQB7l0c1xgcvBHRzwXLlaF0A73soDTG+6ZOvM7QSmejuWXiMdfGGHpbuA/b9SAG9Zf4cABpOPzDw6Nfxg3UkfcfVPjQkFZAYtNYWwDK5aQBSWhvKfjerlAX5YJ1L0CfOMv9EHyG0bwMVwFxq8GluYTjz8LWAFHtavxAI73Yk9/aq+aqXjl0s+LgRe0CyD1IoJOJp7IizJAFoAgumOoxYeL6gt1ADoIhbEaVgNAZ9wfqYrpPPNumd3bfpbwIPPOoCPrxu8YaVbf6qW77aRtWT9ndQaRVgGAHJcDuHsoKVthqaA10d9iIWJNuU7aGFylIFC4Fkud1C0dhlIOyR/jdG9F7j5WQPw/vmF99dV/6N1pXWSB4MAV1hFLmYcor81dR7YUtA51xPyInFpYYun6BMfV66CeG9eUNfoz9CUU1+K6gFw7TMKYO+5p9n96+/9W1X1lcjM3BuKtBEVwLKSa32XIYg0JMsbL2nQypy4YpECwFgGD5Dad7T9Y5VGfaNlu8gJGSbTr5lp3WMPveCLgD/tAG49e5vdV935d670B0mJlAkjbxULqsQV0VFeUDkRQTYAzmX3DKGH1bmgkXpBz2KsKOR2BZigKAbA3riS+pzx6Xs3LNTnfh7wpxXA/vN7f8Mh8LI1hBIR8UIeD7hKSxSCsLJ4Q2EtEI8i6lXkfkIFkZWtutBPVkbuLA8ZrQ92hFGfOdm7bR3w308bgMe+96T3m+tKE0XqYRgRcRvlhWS4vPDzwnI5zE7EtgxzlOWoCEJl0qiG0sII6x89xSJF21wOlmSgBQaE9i2bhJ1tWlgBrn3KAF501aUC2P2uU9+A0kcNt2RhURJFFGVt3lXUQVweFlZM2ltfWk4ZIkEOeQDiCBQgewteLgRpIriIIr3xLAoPm15irNwB3HxwiJ6SBe5+4749qep/yuTrkONmoJxL4YWTVqT+BLgQD4JMl5xiRLQky1dltL7VBW5ORiWCBEFnP+yilFtCb/qbYtw2NbBR5xg/MwOT+fmVjX0eePCXBvCSv79gxrvDq0zanYCUtTM8a2RQIkVAKySCog4REChSnJAWVxiUSk9L2FJQt6F1uIZSrxYgEWsesRwTaNTOUfhdacrp75YG/wGs/FIA7n77KR90qy8f+aGIfDiYPGaJE9u0KLvWWooUEMYWLGgEXuZ5NuoY0BHtY+TC71luFxhFCtSM4Nn64q1B7Vib1l3tMFVD4Mu/MIBv/cbbzqHDRzDGXQlrVTWsWUWF94hxA1jHWxBdjmcLCbdU0Lk8DCjSx6ChK9dmYwvOB1hORNSQEIl+rimifeBIxLiElAOb2x5T72vA/iMC+NefvaJ6bP3yJ4ZWn2pF8mk4jcKOe5a3mX2z+c9lhJyStiN5cbKyKinplusMnLCzkZMMaw86Rl8aXZxwIfH2AFtBU4/k2gBERPj8wetxqLfRmfkXwJ8UwJ3v2fe6lU79fhflxIq9aliSXI006kOPBtTCsQmC6gQoRTRs5RQLhUABAu4p3k0US6BKa1ZhGFEHBJ3x4uACG+xiaLcAt/xcAH/vmrevG/RWDu1xfTsSmPBwJjh1MTB5+qGOAjRPkHcCCS9p6QF0QZ38UVhWWD0UeaC3DbyRR8pUWHVQP57L8QjFgHILGdHOgGqrDec/A/QPC+Ap7zz10roavBcZ0ABR+gtrA0rsKctJCi+yqhLiaGY58jkuRY/yMGK1LiKpI7wNFR7+L6w00peodOIcEgvfF/YPMQ5SeUiBj+TYcLusfxNw6xoAL7/+VZaq8Y8mGx4XWyPIhZgzFmZNUK98jntsvyjb5nIgUFAoxkSlRaCQFkGg9JFrPWMA7LEYCMv9YhEpfKdiE2QO7vO9+076J8ALAPe99bzzB9Xgjx26SBQx1oEckQR4Ewwj1sVARUQOmik29qBIXBJeWMSa8z0FhE6kGkXi0uaBQDtOwinTotC0dNRO6MlozBi/yBgMczsqTR64FrinAPDU3z71PbX5iyQgQn9k6aWrAMvO2InVl4eltsAXNrT2/C+ceixOUw7A8nMTyR0KIDycRQOKiPeWCXwxt7WsKa0/vqfKaZjqruSPA1e3AL7phis29zvDv3L5vNxATphygJHRijGKBKpUPigT8AWdY0qGQnEvSFTmHrE7AG+PyMI3+whcZNl2ajxb1CoIZqUtKmhqirEidSPfW7aFLNmcD/VpYLECOPkte89Llb+7BYoi0EYhg+Tx4nxzQhrOH89lCAWcTGdaCIu3tPcGz/BDLsciguOxQCT6DHyRAQtgPca1lQnbSLeapvY+w/RTsAqpk8coJlicRcY9zN894W1M9XmMa4DbOwCp4xcmhDme01Ag/hOo5veKUSHkDQARtUNGBtOh/cMpHDoEsI5ydQCaZFSoTaeGrOBpiHmHiWqKmc5ONvV2MT+2k40T25iq5uhQ4TrUcrjAwws/4K6lr/F4uoMOE6i1LEitFWdIc2YQW0tvv0lMchdJEhcCV3f+7B9/v3dr/chZw9KJgEPMM9M6T4yUwBx3YbKcl0GKUznkCXcnZRUMA3I7hyI0OAQNM0iyfHZXU3vNkBrVQ0wwbbNs6pzI3NgJPGd8x6H7VqY66xm39Zg64E7yYbu44715Zud3cPTM6XznkX/jwcX/wTSV0yBrw1fK+lhjQhlMEbsrSEqrbXRWtbS3V236o1NOGnTqdwIzyAkAi2BSJqIEnctMuDyOCnl4FScaRkBWVpK8EDU1iwz8cXBj2jaxtXcip0y/mD2zF3P6hsvYO/Myjp8+jU2HwJvuzFFpbGQ5XuMkwAlt06p8QjNsnDqBxeWHeXz4Y2TV4b6iL9Oqsi7rOdKV7oHPdZIPdwKbAZI3KwAE2QgrihcZCh/lAU3skb0c3olUhAoDrKGn19RphVQNmGSaOR19CJhjOGp8F8eNH8v63jyT1QxjmiD5AKcLCCXPdEsggLrVLgCIudRaYZz1nDj/Gzx83+0MtYSFy8tzpZ2pNRQn/DvZOJLbZq+HO3XZ9W/6k7ryvxQUh5UmMMLShEdI16hspFELJZDaX04BWJOoWsKcEdUzYEMGqw5fWmZaW5gdm2dHtZNtk7vYOvYzSm5grFpHV+PIlSNqijAT0zniFXtmD3KZc/PD/8UPD/wrHeu1B7VVZo2ZMBcVjkjII3MwRvNMI//9p9XuN5/1ttrqvaXlChSxs6Cwym1b3HxUJQvl82a/r2UGvszQxYRNsK1zAs+beBHnzr2cF89fylkbLuDUmReydeIEZqufRc6JNnVKDAEvITkyeJlJFUPv068fwwSVekBCMjqaYP8T18XeG8r355LH0K08fHfnvs7AhsdFRAwgkjsuxxpq57IyXQ0iuiawJmPPnxVfBK+Z6WxgR28328dP5NipnWwem12l5JQmwXIfNzyBq6ZWDT5aZ0iIFLTMekQ4i8vX7E+M/Uvf5aZHPs/y4EesGzuG3RtewfaxU3GvmetuYH1vB48OfoDoEeR3PGcMNd7u1809Mosm4JGO08uvf9MdGMfbSKkwQMCaFzSUVDZjJZQbxSm0r7YZpD5jPs4ZG87itPWns3XqWNZV6+nSpaOK5CM6gpMoE+bDJ6EhO/y1tt5U8ejKPXz2gb+g70+sWpt7zaRNcfGWK5k9BKZI3PDgP3PPE/9Jz6YzYyqsOQv0hNzbnU+Fj+pcIzlg4s5Ocp9VEkmEr3PlTD+UdKKcPLf1qDPEQn2Q06fP4OKtr+Q5Uzvoegfc8FVlEkNSQf/Dx7myfGSy6rCSew7exqPpAdbbJpAjjXHAf8K9B7/H7PhWLHWZmziOuxYGJBlEDgjyMAwfGUaKw7XMTJHQXMdhOtRukWX0Hh/JBXVDYcLqDOHK4KVFzpt9Ca8/5vVMd2ap68Soex8M0i/muUoM9RRlguQVKXUYCrB6xKB+TTZ+YMjG3hbMZhiYIzcMME8kwKTAJN+Tl1sLySer49+y589Xi5HQRsIS65DBtEa/OImWGKRlTh7bwxU7rmB9tY6hp1znKHoUJyyWt1VSBTbyf0SCvQYUOeVWC62VudqEv2vGnY/fxLIWqDD6rLBOR3PG/KuZ1HocBxP7F29mxQ9QeYcRuokyYHnEXwkwaL/noTKXKTyNwK011oRR1EWeF8BiLHniwi0XMtedZYgHPWNPHJv1ylYj4/6lO7j10W/yvUN/9y7dxcAHmFn0LC5f/cRR1eFlnhFNntg49hwu3PYuto6dySTzHGt7eOmmdzDTPXq1PpEYsylmescz9JWsayLJqYEay6dB4YlTfk5Sc9ArXXjd5S5PObyOUK5wIL6qNBzMR3AVeSAM3Tm2u4X3nfSHTFQzBdjg5XGUpUOg3cw1D1/N7f1vs5wOADBdbeDkqdN58YaLOWn6tDhJOXLAeNIgY1Yx8D6Depme9ejaOHWqW9ZX6vC/B77EjY99jEk25DFzzupQZV9vAmvMxXNfUxtoYx/hik3/qByxMIF7+YeLflrhhLHnMtZZTyImrShibjjwlQe+xMfv/jDfWb6BTdV2zph+2erfBm3mpqUb+IcffYjrH/1idhHG4QOGjiCLK6WajneYrNZRMbYKHqJIgebHtqF6koEnEk4CmpQ9ZWurEamZd5kfeHX8m/d+wEXH41ATiDttLtRIy1YraZkXzJ7JCXMn4gi8CLR5tTrc8titfOLHH6KrDpdseAOv2fZGXrDhbPbNPp990+fSTZPc1v8Oty1+mxMmTmN2fFOm51MIImua+M+N7JJx98I36XMQqSKY10w9DCvOLds3DqyGxdRYXbsCUEMux2BNx9pFco3auY8CAgGeh1Gsyhd9gS8/dDXLvsSvz7+Ki465jLneRro+Rs/HmRuf5+Jtr+SCdZewsLzE9Y98lYGvxE7AnQgYAcbhZUdOdBxv7xOdGWZ7xzL0g6TW9zs1TpKTPHtbOXUrZ9TWWaiO/a19v+PyufihZKtVAYLFkiEsLFADTp7YxcmzzwVXAIhn66u49+B+PvvgZ9jU3cTrtl/BOpshecIwhOGqqaoux4xvZ9+6Mzl5fi9TmkZEPkqMnzU8koyQeSErdyzW40D/p9y3fCOVJtdYfdG5/PUTwP3Vzsuf/1rJt2PgKTctggjx612zoLAsvysxo3HOmHseUhcXxW+aK1X8aPEePvWTT7JnfC8v2Xgh1oxh8aPwRKLXmWR+YguTmg49R59QPst46rIsp3BDdyxdi9HBs9Q89zWP77pRU9vgcku16/LTXzqs6r1hOaOaGLw9h4/uEu4DHvcFOtZhpT/grE3nMFlNrf11AmJh8ARbfAtnb3wpGyeOopwCMVmn2eaVoaF849MgC+s0geTcuXAjfS2BKuTgDQ5rLDeMqkpjX6l2XLH3ZDe/IKmxzGgWlLYWWAMGDJnwSV5x1MV4WuG7S3dy5uyL2DK5EU8JqTzo39Cb55T509g0eVR2xmBrvg72UO4Z2J0EjBVV3vM2XOtUHX68+EMeqR8YJfcU3zhGWuEWv3F0gVefNtxvxrUiB0sGnhPIHFLCPwtzY4k+EzbOu3a+g9cf/5tcctQlPJYOcP/C3SQcD99TpsFDJ9V18zIiSyrbldeTBYzYOYUMQgYlG0SFsVQf4IHlu7l/5U769SKY0avGOGpiF8PUR66cTCdqnEhtABLeBFJYGSS/udp+xbmdWvVlST5TUssR8fWfMBbVZzOzvG/X77Jvw24sOUldrnvoG8x1euyb3zdS01l7CcLC/MmPBvwIwaH1i8CahQg5RLpVa8h3n7iWzz18Fdc+8UluWvjq/zV39jFWlXce//ye55w7984wOLyNIvIOUhUVUVRUaIFqaLVLdNWl2axxN31xN21NqtY1beo27VqzsbuI+0e3u7rptttqq7Zpsi0GxOLyZhVEpIAQEFCYN5j3ua/nPL/d3jy5JyczMDgOtt/kyZzzy713cn/nd36v3+dcjhUOIVEZsRm6yq2cKO7BSCb5nDRTiTT507UEwlP2lhUreroa+2+PjUwVfzWT+UQyeCxphclhMw/O+wqXNc0lcjEqggks+3v2cbzQzuKJi6m32Vq7BxmmcvBrMD1NajzrQYFgMP8Ua6q3JVYCEDPIksXCzq7f8quONZTpZkbd9YwzF3K8soM9hY3s6XuV44VdWNOQGnYlXME0S0KAwAW/n9I17V8sENtrJ1wmsLjGk/XDAFFTawH0a4FHL76fy8dfSiUu+WJayJHheP4EG3pfZ8W4JTRnxoM6r5uzdvBDngmc8bVGLAUKvJvfxzt9e2ktniBQSzbMYU2AIcaYgEP9v2dd+78h1vJnzV9i6cQ7+Fjj9UzOXkGdjqdRxzAxuJiICmX6QCwJNc6kL7WK9+L258BvDIBE0XrFebeScjPVYwdYQo72H6Wl1IKKI7Rh9YoHWOY2zKFDeziWP4AR562XoaHDybzleZbB6ZRnjaE36uSF955h7eGv8kzLA/xn21dZ2/Igz5/4AQd7d9BebmNP3y5+0fEsJ7WbZWPv5fKxSwg1S0ayXJpdwKpJf8UdF32Z26Z+jhn1CyjFBZxPllNlm/okW5BYhEjtegALMOG26b3OmlUKEzx9LMnWfW8sYwJe7XmbrR07aO05xkCliDEGm8lwIt/K1lNbmWmncPmEBaiADL5lT9+SSnRTa86eirqJRckFWX9FSVlePu7l2eNPs33gZeZnbuQTk1YzM3stffEA7+Q38+bAZnb0///qW0+fO8qSsX/OTc23IprBqMGoQ6Xsb5JMNaHOVwY4UHjND5oA0mOKWmqIORBG4WM1agcw0Hjp5LmRxNcJmpivX3j/VGcMRZfnzcIh/qfzNbaf3M7+7r28duoNVLXqFxeffw11pq56ngoBw1cOPvE2tJdaWHPwMfb17CEjIY3Z88jarI+klrKW+fXx53m571dc3bCU1TO+yPyxC5nVcAmXNS5kWu5Scq6RrGtkavYSbh6/muvG30IoWVRdrQBQoTb/ECz98Sn25bdhxA4aY4mQcAxV/ht4AUCWrfs8Hh8fyJR/bXD1pjbaFJLnFzgwSk2dBpxG1T5exoSEElKkwtrLvsW0hmk4F6VKw7NtSYkI3VEnPz32Y7b0b6pGyQX113HDpE8w97w54AybO17hpVPPcn52Fn8342EuzE6m4mIEcBisT/RLGpERQ0jGN3mVNNJWfSS/h+fa/xFLgPXKMt4HWqS6BM3bmE8DmwBk1Xf/Gg/TukjXW1guxtUYMiKmFlFTu6OM+rmvIL6H1hV18ejsh7jpgmvROGakEBEKlDjUc5AtHRv43cBWyprnorpp4KCt3MaU7EzumfEF5jVcQqwxzs9oTI28JJDyYcqZYMWye+B3/LLjceqkAau1nZ/+2BuTcxtnlt++GXAAhgQucPb7kShOHd5p+gXgzxOCMZDUxuqUgD9EvAO1We6Igoj/svWa4cpxV3DP3Pt4cNY3+OS4z5AzY8gGjSyfcAtfmPElZtfPI3IVNP0ZNcqwS7Wyhov7MaeKh/33MzWuj1NqiXRkHMZlvg+4ITnS8ZTm95DiUhU3DQTEelJjir1eI9/grbPgKtSZDLFT6ghYNHEhGVMPOJTEIoafa1QPErKPKqGGXFB3IfObFrCo6QYWj1/CgqaFjLPNqNPkLYDoyKZVIpaCdrOx80WKcREjphYD8KQin9ZtyVXst9Ik8zTKmfPD/tjIXWkqLj63ExDxztcAcDLK87cX3cHfzFxN68BJ3s7vZ/nEJTSFTShxqjgYviWliSwJ5TgcRgx1NlsNUIIFAUlp73S96eFtTwzs7HyVHfmXCGwOjKZ0bcRhgIqxXwN2QoIA0riw4F54d4ysiwwrLYoBdIiRrRPHqUqeb8y4l1unL6dOQq4bfyVPntpE68AxZjRcgIshpSohqWPPIEsVvwl8pyahj5x+x4SSfP9aRTPICo1YEGFv7+ts6Pw5tjaWSBOpYgyCXVcf1z8PaQQMRmzKwbclG13vxDUh4pUoCckcpT8u8+isz3PLtI8jTqqyqWMmg3Uc7WthUTMwTCXxQWSavoqDrSilyLSFC4M5z0pMV6WDnb2vs737Rco2xmA8eTGZiRgBddJNxX4biM92s+F7pbEyRoxZaoZywxLw9Vn3smzKEk/1ihEMGRuyr30HOFg86WoCglFtSUn6+OwhYKxQocLJUjt7+95iR9crbOh8jrcHfosYz9DyNbymVY448wTwXwwBw2kg5TFPGBdsUhUcyebmosZMt01cdf58smI9Z8YQ42gMG7i6YTZvFQ7TVe7FnGk4jn5QmT/1VYGfk+BlDEk2EqwElLTArq43+OnhH7Dm3W/yw7Y1bO5bR4/rI2fHpXyB1pgYgmIQJ5uCSvjESDZcl3L12Z0lG90F1PtsnFAMXVqkq6+LOC5hbVAtt7KmDhNYjuVb+I/Obdw+7hqmZJtxCfVrqCAyElny5wyM0tgIxjiO9B/iZ+//kJdPvsgJPYKxQlZyBFKH+sCV7DNJ7zI10JGpBJ8Fjn1gBY5dPF2Atgg9DqwCjOA/XGB3/jDPd2xje9tbHO45yECln964n+0tOzlSfJ+rcrO4uGl2zRKQ0ZxrDJalqSMQCuzq3M7TR5+kNX6fnB1TrXENcpqHnAmQIHQ2CjD3ARv6g/eF00Bu/M3nYHj8fSmIvqvWAWBFqkvU4KqtriJFLZEVy3lSR4kKNzdezVeuuI8sAcq5h0KNOSVG2Ne9h2eOrCE2EdZYRIwvTT1Jw7fljVGSDU/qy1YhjM0jwOOj9diTzbG1Y9W6xQl93SfVQFYCGiVDTsJaatDviqxovoGGIIeiQwWHUZeJr2n7on5+fOTf6aKNsNrYEJB0d3FwMzcp3YTge8A3YXgYzhKL3xz/kI3Dp1QtqoIq3pk7XHWBQ6srlJAD5Xba8icRMSgpDBMwRirzujRwoHcfhwrvEEgOl9TCvrpJsk6F5NgbhTjz1OR3Fn3tXDz6ST/WevtLJ8YfGmNcfINIhNZob4lL6o4LFKnQpiVuapjLnKZZPs2pTbeGCRgjkiU0NFG2ntzE3tL+auWiJlG24PcvJxVWjb7r7fef53DhA4ADGFUL9HDAg+LMIzEmciIko1A4Gvdx56Sl3Nt8K00ux+Hed6loNPg6DZp1fHgZHrE6uordBMYmOQnGUzZ8VVKj6BlUhNjEkVN9BPDKO3sEjAyPiwuOIW6NIJNU4Hjcx0OT7+TueZ9GnWFX10F29x0mXy4wJtMAbqgUeNRkKat0uBqPhzghCFDbcZmUeJELTgaauR/4CSOAYeT4SUPRfjKWcFO/Ux6e/hesnncbDS4kZ0OuPG8u2/JHaCu2YkQ5I/TDywRq3L4x0kDklGoRIKbm46rnKLH33VZlUxiHK2rK+ygVGDSUBdj9xqGnV91zwYrv3DltZXdOM0QCRgyzxs3gaJznaN8J5CMMIlYskxovwrkkgVdVXDVAKMYp4oJujflOphysAnY3dDXJH/MhtCXgldVTP/O/qm6KqMwxYohV+WXbFubZCVw1ab73OwrKOQki1FinYXWytq17E6HJpg1XlLCSW2eiui/62rbEh4SUuguMImwx6+4UsV/uintufOSN76FW+adrHq7eVlpT4JBzkhHL0rPigFPlFh478Bj9rgdLiDMxmTjYYjVYa3vnvgDEjBIMo4sYeK5BM58KM+HdjbZh4/6B1nx7oRtjTDL2PXua7gd8nahSYWxYz+zMHEouyquzG4Oo7u5csf5TwM+AmFGE3P/ULziHME9O/Ncl25avveOScbNWOvRizikM4BDiAxuOv7zuH4498eJnj//luX0UfMdADx8Rmo0xC0XMzRi5XpSpCs1AHcIQSG/tT2xsSB/cLuh76tgOsj6OK8P+GMGf6i18JrQD64AHrMoyo6zUKL4L5evAj4DNwGGgU9FyRSMtERG5mCiONVYtKXQBh/1rf1R9b+zuMsrKOqJlwAP+f7TzEeH/AKvWfJCtGj82AAAAAElFTkSuQmCC",
+
     "version": "0.3.1",
+
     "updated": "2026-03-06T08:00:00Z",
+
     "home": "https://github.com/sethyuan/orca-dinox-sync",
+
     "zip": "https://github.com/sethyuan/orca-dinox-sync/releases/download/v0.3.1/dinox-sync-v0.3.1.zip",
+
     "translations": {
+
       "zh": {
+
         "description": "将 Dinox 笔记同步到虎鲸笔记的插件（同步到日记）。",
+
         "category": "集成工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "flomo-sync",
+
     "name": "Flomo Sync",
+
     "description": "Syncs Flomo notes into Orca Note (sync into journals).",
+
     "category": "Integration",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAFuklEQVR42u2aV3LbSBCGdQQdwS+bJJGcJRW42gTnXKUj6ALOCgAIQmNy09vyBtQNfASs6IVkUwAGDPuMI/AIs90YoihQJpgLsAtd9RVz6H96Gj09s5JaaqmlllpqqaWWWgxGmEqIrVIkzxYPAbJ9CJN9sn02mCzFL4CjeMRV+fKQeY4d8ox7yDfcEt9gZZ4Bck65B2LciNV5ydQpCLA85wUoAHAMjpd4xjnx2flAX8br/AW9sW1pnDCNZ93lknNKnNhXOfFiD/28rb4rOBrPL1+AIOR953eaZf7AoPGG/m5T3d9yZF6Ekdl2yr4IZEmgAGstBea/4otw6/3bWqzOY+LJu2+8vHvgC1C0JxQgPK8nF6ClggDHQgAI/QfGn/GOPiSk+nr3JUcKEAVbtgoChJ3Dx9eRh1BHMiyWyAFlvtWs7MfqPM69nPuGr/33XAjAjq4JIBjhtHskYPJIiIuEIwWdL168PV2J2x4ZOsUIyLVf1on7ur5ly4AK99V6bgjiIw9x3EceSc5HvUKpDqFfX3jiSy211FKTDLqK1/VNdiDhLWF09Yt2eA8cvn9WfXG/8fu72ybtbVtBgTK4/OBzt851/qBBgQp/dFbhj8+o4J9KCHxtYhoUCT0XfM9TwfBjb2GZ/wEsXPByAmVlT9TXeh8NWfZqbmQVmO9TcK5g6z67zfJiih4c8W1LF46HiUmAMEII4fi2BVxS/r1DjQXU7C9XoVQ1Co74kaQKgLV+piWicsui/OcPFT53vV+EhJZtHXmkdcCJe4Q/klgBMvDfvu5q/NuOzgmj/N5Zlc458nQ1z1QvlNyY9nkI4FTmb3TsWCdQn2vcx6r45B0KIugJngKIzgtWdW++bN+o7GMSEc5jQvmNbzf/gARDQQT9k2vt4QZkQLY1YLwjw6s4JGKFNwzT4X9W51/tQRb1AkfxtmBjBCDUFyRoYYnbwR8Plq6YLzBvQP7gmfYRX+sKIkVAsdriM4Pmh1j6FtgBEr0Exv9q/QXX/L/nS3wZVt4PhTXTMfRx9AcC2L4IgMp3LdW7Z2r0aYPuPTGohLcPG/rp7XPVK1pCjPXOAQhwEC0A9uo7BxJWk3feU+kJ8OC9Brd9DIRGUJXmdh4t65Y8dHxYBCGEQDzWenmmRLaUn5xptGjjyL2G0X09JoRlIwG7M5o0IsGFKi50fqupkomaH43y/q51gFNinAAca45YBcgyjUYJIMLeD9epysvbpl6LdD4QoH0Yb68u42pGdASo/IdLxZhl8YRREy2An0DjbVWDo2xkodMSo3TXnG1xAVOnFu28yguwSRK3AHycAI9MSlZmsAJT9sYK4JS8uJMgjyLHFD7PRsjY1ZyjJ18AnM+z7v9HCCAKK4uymAUoeVEC4LbyXWO2KUDGTgGNb11WjLgjwIgSQGwq0pmWmbhZMVYAK/YNS602WgAd99P5zsdyD5ug026FEfe4N1YAu7IfeyU4SoA8YpUF9vFUI3X335P6uEKoeKnFv19PmChYRgpgK0DJzwX5S32iqXDH1Om2JS6hUcveu6bGknJaiw7vxYtKEHAUHzxgtOaW+TrMa+ni06O20ZGlTFsxgvoBgftIsMYPCYxrhoQI8HIVnOwB4kCRe4wnK4BS6LRFAC6Pb5tVdr9ReQeNlPotEztJJU84G+7YrHVUvt4WPQOxptB5llG89VaSZMWPKiXOMSd4qgpYawkRsu6UpzfcKAEwAkQH95aJyS9hBqPPNq1jjojzdcejj6RM0bZGgimAt7fP9dOVJBrO7Z2m0kMBRCTMJUDos1daZ16iDyxIJiXgeA+mg7gCDJqgyLTd4ND2Fbbch09oJjYSik3FW4wAqp/8MEkWLxI58hGVnKOckkgB5AnyACY+ufbZbp8/gv2C2yb1tmxfhFCfYJwAW5Zm3Lmg0sqXYLfP6V6mVToF53uhwuZ6kuwBNSDZjqeWWmqppZZaav8D5oZBHWyNNnAAAAAASUVORK5CYII=",
+
     "version": "0.3.0",
+
     "updated": "2026-03-06T08:00:00Z",
+
     "home": "https://github.com/sethyuan/orca-flomo-sync",
+
     "zip": "https://github.com/sethyuan/orca-flomo-sync/releases/download/v0.3.0/flomo-sync-v0.3.0.zip",
+
     "translations": {
+
       "zh": {
+
         "description": "将 Flomo 笔记同步到虎鲸笔记的插件（同步到日记）。",
+
         "category": "集成工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "hidden-text",
+
     "name": "Hidden Text",
+
     "description": "Provides the ability to hide selected text (for folding/obscuring content).",
+
     "category": "Editing",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAACoAAAAqCAYAAADFw8lbAAADiklEQVR42uyUQ8DkSBSAa2zPtG130kEjmXR1dafSSn5m7PPuZW37tJfFbXFa3NY27pexbdup5diefHEKzw+YmJiYmJiYmJhcS6ZPnz6y0Zg+Utf1geCa80xfbd68Ea1p08aAqwGr0xsWL7V0nDu9RIRdr0CoDwfXiFpNHyXgrtfsIXY12R8ZssCVUq7rRXc0vy7OVPY5jA0pVn5IUfSx4CqRtSmOFI8eD6TFbXEW7ffE8xvESosBV0Ox3Hp2lCOxIMGiA/5Uaas3zL+pyVMc4ApgGGZAu2dO2OKnv8oU8BFyOSP8Wq7cePaa5FEVd3Za/fSKFC8fIpfh3VXRdPkhCNXxl2RsUR9SQiqOMuhzV5RfT5Xqx7PF+jF/srS12TlpUvJa5T/GM4cp7cnvJ9jqvn+VDaSFbf1Gev9Mc8qz3ljxnmypgROsRAuaNgJCODxCi1kK1mFGUB6L5eCnzgi3NsGhA0TJfxXF6rTfVJUYe40QUX3qBG9mKVEwm1fW24O5laHMxB0Rqrw7TEm7yDOYFrcb/3ZaA/Sq8d7scpImoay001hz8N8wO8LM2ihT+TxTkP/826PCFk6qTjdE9AVXC0K60+ajfiI5OsGbXSYJ7aau62ODMf5epoCfJwWRYNC+uHGFshN3kHAS5cn/dB4fIgqRMU+c/5CDSo1h1KGsUGkSD6fz8mF7kPkNNnUbuBoMhYanWPlF4hnisUwOPX3KcB9gwIntH0nlGoasK01svEgV8NMWX+Y9RsAvJ3n0R5JD+2mx/l2r9X+vhBAOThTQM95kcTPZO07XXmk0GoPAlVIQO6EzzK2N0nDvBHfmC9L7Th0PGZv7YoXFxvgeb7T08b/CBEEYQTznieXfTnDVA0YBLWJUdejpfbQ2yhKm3vWnhG0WP7WiWOkqX3kfbU6VHSFmDdkItrqmnDkOG90ut1HFgZS4LZqCr+u63u8Ur/UPZMVXPfHCRiO8ayQJu8EZFOuaPsaZXEDyGqmTMbhSIHymf6U1pVVudKj/hvpUeEFj7SF2jTuW3xDPyQ+RVnaqt4NZeP94T2apLZhbTfMyC86mbxEpPFK7ELieRJPlii2QW00UibLV3jPHfdFSxyhnYvE4X2aFUVw1cLNA7Vn8WFf6T1c0/7WEVf+Z46LSlR1uif4y1B77Tap1xcHNRNPmjVBPKZQzwRgPg52do4GJiYmJiYnJXc/JDQsAAPUfFcYbQYH6AAAAAElFTkSuQmCC",
+
     "version": "0.1.1",
+
     "updated": "2026-03-06T08:00:00Z",
+
     "home": "https://github.com/sethyuan/orca-plugin-hidden-text",
+
     "zip": "https://github.com/sethyuan/orca-plugin-hidden-text/releases/download/v0.1.1/hidden-text-v0.1.1.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "文本隐藏",
+
         "description": "提供隐藏选中文本功能的插件（可用于折叠/遮掩内容）。",
+
         "category": "编辑工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "lanterns",
+
     "name": "Lanterns",
+
     "description": "Add a festive touch to the Spring Festival.",
+
     "category": "Visualization",
+
     "icon_svg": "<svg width=\"512\" height=\"512\" viewBox=\"0 0 512 512\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><g transform=\"translate(256, 230)\"><path d=\"M0 110 L0 190\" stroke=\"#FFD700\" stroke-width=\"12\" stroke-linecap=\"round\"/><g transform=\"translate(0, 190)\"><path d=\"M-15 0 L15 0\" stroke=\"#FFD700\" stroke-width=\"6\" stroke-linecap=\"round\"/><path d=\"M-15 15 L15 15\" stroke=\"#FFD700\" stroke-width=\"6\" stroke-linecap=\"round\"/><path d=\"M-15 30 L15 30\" stroke=\"#FFD700\" stroke-width=\"6\" stroke-linecap=\"round\"/></g><ellipse cx=\"0\" cy=\"0\" rx=\"160\" ry=\"180\" fill=\"#D32F2F\" stroke=\"#B71C1C\" stroke-width=\"6\"/><path d=\"M-80 -155 Q-120 0 -80 155\" stroke=\"#B71C1C\" stroke-width=\"3\" fill=\"none\"/><path d=\"M80 -155 Q120 0 80 155\" stroke=\"#B71C1C\" stroke-width=\"3\" fill=\"none\"/><path d=\"M-40 -175 Q-60 0 -40 175\" stroke=\"#B71C1C\" stroke-width=\"3\" fill=\"none\"/><path d=\"M40 -175 Q60 0 40 175\" stroke=\"#B71C1C\" stroke-width=\"3\" fill=\"none\"/><rect x=\"-80\" y=\"-200\" width=\"160\" height=\"40\" rx=\"8\" fill=\"#FFD700\"/><rect x=\"-80\" y=\"160\" width=\"160\" height=\"40\" rx=\"8\" fill=\"#FFD700\"/><text x=\"0\" y=\"45\" text-anchor=\"middle\" font-family=\"serif\" font-weight=\"bold\" font-size=\"140\" fill=\"#FFD700\">春</text></g><path d=\"M256 0 L256 30\" stroke=\"#6D4C41\" stroke-width=\"8\" stroke-linecap=\"round\"/></svg>",
+
     "version": "0.1.0",
+
     "updated": "2026-03-06T08:00:00Z",
+
     "home": "https://github.com/sethyuan/orcanote-plugin-lanterns",
+
     "zip": "https://github.com/sethyuan/orcanote-plugin-lanterns/releases/download/v0.1.0/lanterns-v0.1.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "红灯笼",
+
         "description": "为春节增添节日气氛的插件。",
+
         "category": "可视化"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "linker",
+
     "name": "Linker",
+
     "description": "Manages large assets outside Orca Note by creating virtual paths to reference them.",
+
     "category": "Note Management",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAALaklEQVR42uzRb2iVZRjH8d91Pc9znrOzf27OTRSUQtYq1GCsjIJCCIKQiAxE6UWF7+xFBBEUkdSbChRadIqNhpr2l2QFEo31ohpibmllRmb2T+3oqnO2nXOe89z/rg4Hexe1wCnC/YHvDRc33C+uG57neZ7neZ7neZ7neZ7neZ43L2On7Iq9R919Q4fNCyNTyXXw5u+Vz9WzT4+p4iPvK9k2amXnQfMmvPl7ccLs2Pqelo17tWzap+XxMaPePqbW438IcRl8eOJ0duLHRctSjWUA92hFiyqgKBBBJmI4BpwVmw250hIiaYlJu1ClzknCCLRYOKUtkkRQn7k5x2EmQpAaolQ758gq51g1RWnSvdiVABTwD/o6Zee5Km8pJtJtHOFMUaLOmF/+6FR6F4AfMA+054sCLoHW44Xcql+L6C8l0S1VHfQr4uU1LZ0iBAQCEINEQERAPRYggEXIrh5BQICgcYpAnAOcAFTHBCJcuACBWCQKYeOIas1ZlNpjd3JlK33VnuU/C7NpOj1jbcAk3e1wLa3x1iM/Ud9cKnDM6IgFfUvx/dVddjOASfwH+nR2CgsgGh1bteZcgtsTnb25mGLtjOarNHGQC4FWFrSEgqaYEAQQQT339wLAxhGUE+h6rp4VggWDgMaumQkcUGMGBA2ECw8RjHVIHWDrOQg0ADaAE4EFIGDEDDRF0vicSk1gjEMuFyIbAm2xoHeJTF+zxN4N4CD+BT3xQQEX0YoTvzdtPF/LbK4Y7ocAuQyjIyvV7hZ825ahybZmHO/Kyem2GOXWWFLA1bQWZxyDiFhZCarahOUUUdkEgTGAtUKOiDMBB7k4COMYEZPLwFGGmSmMHBEJG8tBmgrPJehionWlBDfMKHRUFYFEbMgQqnMizWVFmFPSWNj1PTjbFcvEz0Ve/0sVi+EIzZFDb4+cXLd8ZgBACQvpgV1/rL0jP5cfGKyVbs1ruXfEzj70hvrssQNmxzMfq027jqa9Z+S3GJfY/m/KPa9NJf3Dk3pgzzGzet93+trXv1Zr8of0hucnzJNPjat3n/tEbx8vmKWoyx8yQ/fs1nLjS0Zue1XJtv3VkSNnz2exULYMT6++abCyu38wdXcOaXnwHXVg+7i6/60vqytFHiZcIYYOz/Y+OqpHNgwr91e7dhpcRZXFAfx093vJy8qiUqGQQqZ0mMHKiMAgDrJvwgA6EcKSsJWAgkOxCRSCoyiLCoYlJLyQhOwriSxZCYSQjSRkk5AMsgREyWBIzELe0n2XPvMS/eBUUcNzJhGi/as6/amruup/bve9dft67mc4PUguXxbfPLvrHphX6zIjwLT9xX2K8vpRhutTldBDhfKL0M0ElTPPDWnEOPMotb5wkOG4w/KVFTGW5YnX6p2hq6w/1vSnMYfkkpEBFNeeIjlxNdY/QzfzSa5pxMpkGvPXMMaH+hMcGyhf8o0yvX205LY7dKW34pqmvnyQ1I8/TPHDLNkPkThAN3O4hKxfflxpnRBE7kwJsEYtjmqZGXG52hm62urjba+NCFDM44II7j6jfArdVEC+9XebvzB7fpBysyf8UrakmIbbOtY0xJ/hpkyWi4h60NintKHBsCCGFHkeoLgkgbLwCmUiaOy3Jc20cpyR4ZgjDD/M5lmIdd1mefLIpV5r6LHwGLkyPJCiTzzBwGK6BDT223XWMntmJMfxwRzXpjBzbKX8R9D8BxH+ixaqH8sQwU3PwdEBASXt7f1Z1mWwhDfiOHpFE1yTRjCikk4Gjf0j0MUBmU4EkAQAKxPBogiTQGO/vfnkkyVJHOfEUvRNpLgjl13J/cbqBhr7hJTKM9ekMVuADL1ttS6dYmQ5WQga+/6JDOqjFtw1wfXvTPCcQRKgtyM0OEpCM2jsF1DMNn50jlkCLvIjmbVkAPzK5d0gjnn1pDd0lsyrxDn1K/Ys/EYEltBtO/PoXWMZ25t8Q/09aOyXV2vutfM8ueEbR3FxMsX3zzFT+CXqCxr7RJTRpetTGc77cdJcm8oxuEzWArRHVYPJ+bNcVrk4sT08ij4JDHecZ1cKas09QPNwYeV01do0ht7xHL3jGL5ziqPxorIBNA+X9Y3ZY1c++9onkeHcWIY+8RR35NDrObVyb/ilIYJQykv0FszTwU9EVNx1i7rK9fAYOlxK/Valso6RNzeGte88YchF5W3oKtszmvovjjFP8w67v2JBFP2HTxQ5ODPEGjMh0JIxKdBSNMlorZoVYq30ClfOzjqqZMwKNZdtTLd+FVWjjIXHTFyNPG5bFiPz4hVbgBQXJVLclUuL/9n8vQE625YT5uGzgq0xI/eT+iEHOD6/n+LwAIpjgjhOCeY4LYTj5GCKo4MI/iWQ41hbeUdz67vpNP3zQjKj8Jaig8dI9b8ae36WT79cnKR0zLrecRw3nuY8okKeDJ1ta4rF59UQYn7ej+GgXVYceoDiu6mM7Sske/cU0L+FlLO5wRVswb4itviDHLZsazZbujuHvB755eO5CEe8LwVdpHF/P0HRO4Z0nBFccZzhwWIaAJ3NWKgMXhSvNI0yKjgvluP2LCVpdri1aEIAxbcS5BL/QqVbnUpQscEhqJQdWZPyw3pvdjRD3wSGu87Tipza+09AZ9ueTfbMiuY4PfyH6T22hkzMumdy946WM57bR9A7kpj2F5AF0A2ElNGJu3NZ/sqTrGPUeUXxjm/f1kxWF1dlHgxdYXMGzfGKZegVo+LaNBUjq+kMsClqrTTMjzT7eR5QcFoIxQ2nFL+gMstAeMxUNJjcQ8up10fnaMaqk5R7xXCcGkZxiq1mR3PclMHuhJdYXoGugOgrvJdJiufGt3eM42pbgOFVZAX8xNKElgmjDlmzhvkTnBpCrQvjSeq6dLIosqbFAx6R4m9J7+hyyyS/fMVv62l2bVkyx5lRFCccpTg+mOKr4RyXJFLLttMkPKxM7tqmf5xN0n0S2wNkuOIER2MR+fxB6785YW1jJhjl0JcClPpRgQRfCyWN7ySR0H058vRjVaZnKpp475uouDZjmxPiZeF/a6hFzLtndouuae0bXN42MLBEHmwssXpGlJPRxlI6Z0++vG37GZa8MY3fXJ7EVa8ohuNDGL5sZDg6iOP0CBWXHmPN72XS0MPFZCj8nwS/Qgp2CLh8V1hlUgRwdlBhWF8he/Wo6ikAoMID7Dzn8eSd75xG3W7RzW/l4nQnnc7tSVcwuTsJjXoJZAEFTrlqEiSw6HXY4O4g3nGS2FU3F+nrnj2h1UEvIiGqg2xVe5mtwlMKiv0UwH5WGZ5WFOwjq2IPmYMzY2DgHJ1VFXSoggNBAWRVADNBsHAAFQEMkgCuDir01gvmPq7qpZ7uako/d54EADc6aUdahYeRAC456nTQpgBQjtAsC55nrg/qCwB18GCNtjrZXiM96gfcbOkzo7FNeON6izhMVkV3UQQQbBdRBRAFBBEEcBR04GZAW4NE7qADVRBEgauCzkIEkLnaEYzMBKA/nqUWEUCUAHSCrQBADyog2kqSmEEnWjwMcN9ZTxvcXaWaHnq10MOVFLz5SuNVAKDQiYTIKgJ2GHa5Tiy41SwaJFRhQC8BPD34HABIgp+h/GbbMxbZ5VmuF/orArg7C9hDAnRUOXdUUXiqVdY9cU+GAVaCT4MoGQRJEKT2GyRUDQJSJwlanA3iPScJ7+mANuh00i1nF6nOTcImJ1FVKJfvN5rRhIJk+cNTYtuikd82dgT2qBXVmV0+zmGX5yeoOCeG4ZvJFA8UKZHQBYwXrrtsT/++/+ZTygubUiwvbU41jXg/Wx7if8E8MLmsvlde/S0DdEf+F+ihFV9w9I1nuC6N4sEiko7YKILGPlGVyphPc+m1gwU8Jq6azT17G3uBxn6X1GqhtI64gkaj0Wg0Go1Go9FoNBqNRqPR/Eb9G1z6iLhFXCFpAAAAAElFTkSuQmCC",
+
     "version": "1.1.0",
+
     "updated": "2026-03-06T08:00:00Z",
+
     "home": "https://github.com/sethyuan/orca-plugin-linker",
+
     "zip": "https://github.com/sethyuan/orca-plugin-linker/releases/download/v1.1.0/linker-v1.1.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "链接器",
+
         "description": "帮助将大型资源放在虎鲸笔记外管理，并创建虚拟路径以引用这些资源的插件。",
+
         "category": "笔记管理"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "official-themes",
+
     "name": "Official Themes",
+
     "description": "Official themes for Orca Note; provides installable theme styles.",
+
     "category": "Theme",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" role=\"img\" aria-labelledby=\"title themesDescription\" width=\"128\" height=\"128\" viewBox=\"0 0 128 128\"><title id=\"title\">Themes Icon</title><desc id=\"themesDescription\">Three layered cards on a circular backdrop suggesting customizable themes.</desc><defs><linearGradient id=\"cardPrimary\" x1=\"0%\" y1=\"0%\" x2=\"100%\" y2=\"100%\"><stop offset=\"0%\" stop-color=\"#6366f1\"/><stop offset=\"100%\" stop-color=\"#a855f7\"/></linearGradient><linearGradient id=\"cardSecondary\" x1=\"0%\" y1=\"0%\" x2=\"100%\" y2=\"100%\"><stop offset=\"0%\" stop-color=\"#38bdf8\"/><stop offset=\"100%\" stop-color=\"#22d3ee\"/></linearGradient><linearGradient id=\"cardTertiary\" x1=\"0%\" y1=\"0%\" x2=\"100%\" y2=\"100%\"><stop offset=\"0%\" stop-color=\"#f97316\"/><stop offset=\"100%\" stop-color=\"#facc15\"/></linearGradient><linearGradient id=\"accent\" x1=\"30%\" y1=\"15%\" x2=\"80%\" y2=\"95%\"><stop offset=\"0%\" stop-color=\"#fff7ed\" stop-opacity=\"0.8\"/><stop offset=\"55%\" stop-color=\"#f5f3ff\" stop-opacity=\"0.3\"/><stop offset=\"100%\" stop-color=\"#e0f2fe\" stop-opacity=\"0\"/></linearGradient></defs><g transform=\"translate(10 16)\"><rect x=\"70\" y=\"6\" width=\"56\" height=\"92\" rx=\"12\" fill=\"url(#cardTertiary)\" opacity=\"0.8\" transform=\"rotate(18 98 52)\"/><rect x=\"32\" y=\"0\" width=\"62\" height=\"96\" rx=\"12\" fill=\"url(#cardSecondary)\" opacity=\"0.88\" transform=\"rotate(-10 63 48)\"/><rect x=\"0\" y=\"10\" width=\"70\" height=\"100\" rx=\"13\" fill=\"url(#cardPrimary)\"/><path d=\"M12 40h46c3.3 0 6 2.7 6 6v4c0 3.3-2.7 6-6 6H12c-3.3 0-6-2.7-6-6v-4c0-3.3 2.7-6 6-6z\" fill=\"url(#accent)\" opacity=\"0.6\"/><circle cx=\"20\" cy=\"30\" r=\"6\" fill=\"#f8fafc\" opacity=\"0.95\"/><rect x=\"38\" y=\"28\" width=\"26\" height=\"8\" rx=\"4\" fill=\"#f8fafc\" opacity=\"0.9\"/><rect x=\"18\" y=\"52\" width=\"36\" height=\"6\" rx=\"3\" fill=\"#ede9fe\"/><rect x=\"18\" y=\"66\" width=\"32\" height=\"6\" rx=\"3\" fill=\"#ede9fe\"/><rect x=\"18\" y=\"80\" width=\"40\" height=\"6\" rx=\"3\" fill=\"#ede9fe\" opacity=\"0.8\"/></g></svg>",
+
     "version": "1.2.0",
+
     "updated": "2026-05-21T02:00:00Z",
+
     "home": "https://github.com/sethyuan/orca-plugin-official-themes",
+
     "zip": "https://github.com/sethyuan/orca-plugin-official-themes/releases/download/v1.2.0/official-theme-v1.2.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "官方主题",
+
         "description": "虎鲸笔记的官方主题集合，提供可安装的主题样式。",
+
         "category": "主题"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "random-walk",
+
     "name": "Random Walk",
+
     "description": "A plugin to help you recap/review notes (random-walk review).",
+
     "category": "Productivity",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADpklEQVR42t2WbWiTVxTHL2NvjFoG2/DLmErtVHS0W7c5xopuRQZjAwcqbebLUmtbU1ftWtvOKYuGdmpsXdq4GjpZnTZZ0pq0SfOiJo0aXXW4CRuFokWpQrG+IOJblZzz9z4xvoKi4PMo/uBwP9wP/3PP+d97rngmMALPmXYjfcVOvFsZwEcVQUxdGkCa0IoCD/02383D+dsYehlzXYw8B53cfABvCy1Y4OGdhR5GUQejWMbnNsJ4E2FeK1mFFmz4C2NbDqHC8R/vKvMzPlwvE6ghZNXH9wstODqEkat3w6y0YKadkWkmvFdHmLWFtqgu/nMUY0u87Mv7k5EIByHHRnJlLA/jS9WEXb14sTwIw5w2PqUIy9NfWtnN+zf0kKXAw8fnb8Pe3w/hVVXEq0LXMqRISBGe7WQYvLx9XQxZtzwRRYrxIF557MLronjd4CWzzsnndVK8wM1DK8Iw9MpqCDWJRvF8mR+6uW18ONeRuOdXlnRRy/oejBZqszw4PE7eb3+ek/kbJ6O4k/+p2YMcIVH/1F1kmOPi07qEyejM0hAWu2R/VRdXTLTIRy1SXCk3Sr0cXNM9PE5oRUkHlXzbzpDv+6XqEKoCR/CS0JIlPhilw0+v6kaleBL8fQJTzDF8PXQR04TWzNoan5e7lQdNEaaGHj5RHeJYiRfORZ2Yqb7ze5EyxUoDE2oJnzRS4m3PlaEYUd/G5xcHoa4RpdlSp9n4VJqRMKFGJmElzJYJ/BRmVIX4nO0g3hJqo3PQvxlmwqdNBOUaLnAzftzBqIvBOHAWE4XaFHdwaPpmhs7OKPUxEt+sdkahR0kEsYYDyBBq8n2APcrJV0WYIv34zBShXwyd3HczEZngheqgnAP7rmUKNSj3o17nZJT5ue8skJqc/SnLtsfzpXi/PvnxLPLw5fIAwqYoZmzqw4gH/pp9jzCap7ci6+ONNPhFC3fdu1cbxmuVAVQt7OR+pSLKa6msCzv4aEUAjbW7kB09hpdFEr0Lb2RZqfmdBhqYaKFWg+sh58hU29Xxkzci/X77m/ZixA9hzJAeCRe6+bI+2Z4Cd8I3h1dGYK/bQ80ZFj42xkwYvfZGvG+N54vHjWUfJi3bgdXfeblPSUCfrEqOjfFmDWHU2tuR2Uh2oRZK6WWLssuDsMqWDGb/yhi15u4EJlniTqEFzf9jZJ6d2+8UV1rxQRNKhVYYA0hNr6dWKTycVkfxyU0cVUwptOarPzCmqB3phTa8IJ5GrgM6JZ1ZeTNEFAAAAABJRU5ErkJggg==",
+
     "version": "0.2.0",
+
     "updated": "2026-03-06T08:00:00Z",
+
     "home": "https://github.com/sethyuan/orca-random-walk",
+
     "zip": "https://github.com/sethyuan/orca-random-walk/releases/download/v0.2.0/random-walk-0.2.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "随机漫步",
+
         "description": "一个帮助你回顾/复习笔记的插件（随机漫步复习）。",
+
         "category": "效率工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "share-card",
+
     "name": "Share Card",
+
     "description": "Exports notes as cards (images) for sharing on mobile devices.",
+
     "category": "Import/Export",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAGnUlEQVR42tVXfUiVZxS/+d687qpcLjpnSCh2Sbw4c2hbWzgtRSpGVP4xw5wifVBm0/wgK5QVpuuiGW267rroVVvNRh+MLahwoyyXHzEzlEq0/SHO1JRmd7f7dXbOue/7IhdLiwXbAz+e7/f8nnPOc57zKv5vZQHCSwL3Pcq2bdsWBgT4hAiC4mPqIo7gwrNYf61WKpeLy7xeVaCgcLk8heGQyysqLOwdH6VyBXa3I75FdCOeaTUaiI6OhtTUjZCbmwvJycmA46D19Y4StwsvEzibsAW64OC3Udj7uDMLh2oQvyIe+6hUEBYWCikpyVBUVAgtLS0wODjgwmJDPEfYEX9FR0cRiW8QVBbOJlwui/z8ApUKRRw2P0NUI1oRfyqVAoSELIKE+HjYuXMHGI1G6OzsgOnpaUkY1Q4EFbDZbPD06VPAtjMvL48I9HjKlBsajUKr9haKlYJwVaUSRrRaDSxdquOT5efnQWOjGe7e7QEHFhYmn44LzAHnxYsXiIAlMU4fLMpVysJjUSVKQXEbm+DtrYS4uFjYvDkNiouL7JWVFc+rqwy2ysojjtLSg86Cgr2u3btzYNeunUA1naywYC8UFORzOycnB9AZISsrC5EJGRlbYMeO7a7UjRuc9H0fwatIOrjMwluh2ESCw8PDrPrISGtMTLQ9Kkrv0usjWAs6nQ4iIpYiIiTg2BIIDV3MJgkODoKgoCCqqY/jobBkSTjvjYyM4L3kAytWfOD081UDOppR4eEMB2Jj3wNSq8ViIdtR+03AefnyTy4kAGpBSBIPz+Vg0upVTMBjA9mcQKRmA869kCzOzTr+PCEhHig2sGStWv0uVm0qNMHy5bEOUhWqfwaiGHq9XkSkqFZWLYHXkQYTE+Nh/fpPIDMzA27f/o2Eidp0cNtqtVBtz8v7HPga+wnCR9iAxFWJgIP27OwsdKCtkJ2dzR9JT09nZ0xL+5SA/c00TvPkWBhkduMNyQd0THJIdrotuIe+KQgC3LnTLZGYWdsNhqO0ph+haFi58kMafPZv2jo1dQOTCAgImKkJiYDDaDxJ84+IwDU8ObPCYMILrFYr1lbJ/mLf9gJYaV5eg9/gfWvXpsCaNSnQUG8Clcobenp+53F0cHZEs7keKIoSga79+0uYwEzPn5qagitXrsDY2JhEhOq5IKvaaKxjDZw71wKr0LwUQQcGHso3obHJTPNjRKCvoqKC1YKnkIUlJa3mDyxbFg1PnkzMn4QMB2RmbOFvBAUFcp2cnCTNO1ADsgke1tTU8KDF4lbfKaOR1MYeq9OFo3Ptmnm6l8GTKGpwFE8+AIWFBRS4ZAJ1dayhASLwR11dLatF1ABftX37irlN8RtfO+lBIcybxEwiZ858Ry+m1LdXV1cRgV4iMGwynWICCOjv7wO12geGh4flzeHhoVBfb5q/FmTITgfHjlVjaA6TCZSXHyYCHURgyoyvnPSidXV1gLdSIJXxptrar/AqaeHEieOvQ0BeX1VloIPIBMrKSonAdSbQfLqZCUgmaG5uxIiWAPHxKzG6xcKePblg5ZOwc70WgePHa+iRksZt+KoSgV+YwGmRwBt4gGQC6Gd8GxzclzXQ7jaB2W0C6WHp7u6G1tZWaGu7AR0dHWiWLujt7YUHDx4g7kNfXx8FFlzXhXOdmH4NzknAZDIBJjiiT8g+0EkEHp88WSc74ejoCHur2kcFGo0/+Pv7gp+fGxp/P/BH+KrV5Kg8JghenLyg+V5GgLMpNe6bmppkAkcNX8rp2SA6CN9NCqsOtPH4+DhMTk7CxMQE34ahoSG4jycnLfTc7eH63r1eujGojXvw6NHQnBowmxtAhdcZYw0d9O9169YSgR+JQH9ZWRkT4NjusHEIPn/hPFxrvQY3blyHtpttcBNxq/0WtLe3UxL6yqG5qanRhbL4fVi8OISEPwn2V/N/QiddOTG5xFOP03vPqg4MDEC7aREaMgepkE9BH2puapTuOQmZi4CroYFD7zTCiMiLDA1YpBDLz1u3ZvPVEJMFN8RXEAXQC0fgB2r08SiMjAyLmZBjLsgJSE3NMc+UXP45qYqJWQZkF4TTAy8qTqn2bM+yjm2e7k5SLomC30IouRXkTsem8TeKMhz+s6EgcejQF3D48CGsy7BfymMHDuyHkpISeiew3kc1ri+iPdTmNeVHysFgMDDorhcVF2EmlQaCF6Xjik2z/pYF+qt0WJWJ9mlGfI/4AXHRA5fE8bO8xhM8x559C3FVHKtH1KLEFPlf4L9U/gFgL4aUqrpk/gAAAABJRU5ErkJggg==",
+
     "version": "0.1.6",
+
     "updated": "2026-05-11T14:00:00Z",
+
     "home": "https://github.com/sethyuan/orca-plugin-share-card",
+
     "zip": "https://github.com/sethyuan/orca-plugin-share-card/releases/download/v0.1.6/share-card-v0.1.6.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "分享卡片",
+
         "description": "将笔记导出为卡片（图片）以便在手机上分享的插件。",
+
         "category": "导入导出"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "simple-task",
+
     "name": "Simple Task",
+
     "description": "A plugin that helps you quickly create tasks using Orca Note's tag system.",
+
     "category": "Productivity",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAY/UlEQVR42oxYCZCUxRV+3f1fc+zszS4KKAY1JERQXIGoiBWVIG7QCmpQEik1pdFEUAnxSMojiiRRE7WkTIxEURQ1ihowajwrCd6IRlcU2F120R12Z4/Zuf75/+7XefP/swMuKSo9U719vNfv6O+9frOsUMgxxuD/a1prIq4MDkAWDoiGxmG/P9mB5B5QhBFuc86Jwvd9IURISl0oiKYHEFOxYWTnAHocyDwahFoiYjg4gElGuJ1KpV5//fXa2jpERQYopYg5pAgHhmEKwanRVAjDskzDCA0umYdIsiviQ4Ppi0RPg4o2rlvwPI9cE1K6blFK6QVNKZnNZmfPnt3S0vJVN+v9HVESLIRoa2vr6OhcuHCh67rEQAK+4gPiRECNMmiINFBS+hi0ip9CT9O670vqlSJpXEN4lCab4/EqQwjGGUkkytA2o9QEp20u7rzjdrJzxowZxL+vC0YrHQobHs6MGzeOzrJte+TSdchCJgtkyEPbGeeMlsguNgoMDPfiQ3MipI8GSWw0ZaXTkPZoHYgdFYy4kZd6jsWcZHp6S8vmzW86jjN16lTSuwK/iu9Dxxs0qkQMtb37XACpGshRQgIt+aVLdNMDqDA6pklDhIQDC/VEzRRxlm+UWehniqk+htKoruexmCCjA6v8oguFvFVdX6JlOrCVa/R2rV3NqhtMYZ533qKnnno6l8vPnDmjotI+EC/1PFwl4whwUBbJ3XwmvaNtcNsn/R++0//vF3uefXT3w3/cde/vdv1meffP5+26fanM5QRTmripR690ARpLN1A638j3dnfctyq57NSeZXM6b7m0sLtdhP7nLPXqpvb7btW+SxNiJuFc6Ozunf6G61Tb25mBlBOJLFlywdatH2za9HyYIUI3jsY0Ndu2ikUvDCYtIPXSBveuS1gctAxcHVyiIQh/gGZd3n3Lz2Ss6gZ/eCD5whNu+6djFixJTJ4GklihkO758u5fifces6sORm7DWxsGpp+SWHgEaDJPqc5t5ocbvfw1plPFEBkDWh3410vWAPCaOg1IAZGoqrrooovWr398zZo1ixcvjkQiYYxV0FKGBxlEoVPGKMVQ+zY7Aiw6DrkWyCUXgAXp9wkfZWZAf22m6VQXi9ndD9/D1620o9CX3hO7/l4z0kj3n3zlJfbOY2a82R/+ogRkAXq4X5WTgGamLbQKLokmmnEz39PpvXC/WQf2rJMLm7fyAKimaS5efP6mTZtuueXWK69c1tjYqJSquJyHIyFEPl8IUwEdhE2NxSQUM7tV5gtX5xG0qj2MH/1DnHeddcWag5ffAzXx1BsvwxMreVMTxOP4wYbMzk/BwII75G9+3rHBO/zbsav+XHXNer+l1TxiSghgxjgIE4tJ9Eu2lNwM/sDrf+fdn+HMJdakyYP9Q4ZR8iMGyrW2ts6b990VK37R0dFB66PhwbkgT1fCv/nUszOHfsOK11nR6OC293KrLq25aWXjyXM5WGSe5jzT25levypSDTIxTjeON95/Jt+5vX7aLMzldO8O5UG05aSmUxaiE6+ePgcdBxSWn6JI1C/QzCUjDDCGOre5z96oLaifuwi56btuxHEENc514M05c+ZUxatuuOGGFStWTJ48uQyPkdgEpbAciIiRMeNizROC7GJmsxk9ACKeACemfeUHOO/f8r7T+YHfMHbM8t+KaKLnkmf8niRIZMxiwsCqxtxjv9624+P6eWfXfnOWzXmRAQsFRSLaBeX5yLnK53s3rDf3DPozW2u+dcxn7d2Dqf6d23cMpdOp/v5sLjucHiaIUxb2it5lP7nsub89l0gkEJHDSKPtMtjpo7UiI5TU9EUEAUwjo10dCM5l5BsbidQ5/4bElBPsukPYhKOht0/6RSdRZU9vlek+R8Sjb96fuva0L555wFdFYyRhaTvCXNCuC5zvefc1vfE2aUF168VGoq6vr2/tunVXXb38oYfWbtmypXdPLwBBL0Y9vZTVNTVdXV1huWFUUrfj2OXKhpWXyltl0HBWGmtGbuv9Uv9nvZ78nabZp3HghmmJhq/L4R7toxmLNvxgcaqQdV+9S0QhZjcXVy9LJcY2z52vNHDNLQpbr6R8pvPT9IO3xkwozF5cO+14lMVjW45tb99RU11DmgjD4CRw5BUQgpPoPXv2kMqygukgNvd9e8L6oawyjemIkTHL7t6lu8C64EyrerxGrSwBsbjq7WEoiSRWP9H+6fX9J81Nb3xQb3nCqmvMrFnqHHJo7dePQmBCGLwWsp+/57/7ZlXPe24V1C+83IgmUHqU2mLRaEUHpfS+dVU+l3dsJ5zwkapIW5a5t3ALEVjBCvXhELhEP9fR5tdA9VHHkgJCcMMQLBbR+RTBCbSgs4Rd1XzcnInX3BO/4mGph51Msu/x1X5hmHGBBjctcB+5ET7dSFpFv//7+klHaZQ8kIOIlVdw357WB4cGKQ+GdvARU9A0rf2qQVbpgqxaIpe5vPrkfdEY83t6M59tHWh7t/etV7B3N5cFlORpFlioSJgZSdTOPcu58B5PgX7rofT2jzgn3QSdY/A4Q9875pyG+eeSJcHp4e0yHbZKpRH+0TqISItGe59xeg4tq6T0fpWuZkoRL3LqmOboDQ2zjvcjoiF3+4KeZdNTy2cN39Qqtr+mZcH3/MAyTcxeIUMdZ7rplLPg9GVGGgpt20B7wMsoA1Grk58Pbtnsow+CLEVgSOzh/YaakMRKeZwZzjiOEyKhAg81qjofcbUWslgamRZyBpx5Q71suJ1r5NEJIjZexCeYlKqFw3JfqkIGuGaC5VI9O1cudZPdAgREorWti3QduN3tyncF56XbLe7SmLbSyfSqhckNa1HmBUkKoUhC91NEIebz+cr7wkObisXiKGBQ08H9+IUsmMBNmyZMm3IwxRA8Jou5Lj/d7ae7PDnoWQmjACo9EB5Z/KKTPfB4trsLuGCI8eaJ6ogzcDCJytOM6yKYJ/xMHT5fZ5PR+Hj3T5cnn1xXVHmSiCV80KeCznJwKSmLXtG2naC217xSvI9ytB7Je3JoSMfBdKI6qOMwO+S7kLj07qY73q6/7eUxq15p/sO71RfeTA+QP9Qf8jJhmJMg989NheQuJnh+qB+T7do0oIQDjn0QmX36YdfcLhbd7Ba6We343EPLkk89pjyPgRU++GEQVlT3PC+byVZShQH/q5U5g0cGBvqhHni8GgBJb5kZ5gY4hx8ZnXgkKI9rQMNEdzhtg0z1M0TNuahrwKZa8417e7q28hPPUx9/aO5p08d/j5tWKUHQsQiisfngxZf2HnRoevWP7PhYb+3S3YXcQQsWWbXNpDGdE+as8NbDaongoUNMjwLxKIyQ9X6yw2g8ljuRMDZlvkCO56QoHSSZQg6Sm2RSHRSTPbRIasUaxsI35iMd0LNT/eVy8dEjJDP6rSncsBnXSpD5iknk3Gk8dUHDlU+izFqRevzrde23XdH+6Gp/KAVCsIqnA/SSsSVMa70X0zSnDdJqVMZT0vf7O6GqyTDs0uUiqsygjjcy0xSoyxepfRGPmWPn6L5uDKouEY2POecSt3aqziWN2FhdyHvHLWiYejxqZtgWyVD5dPA2MKFFw4lzEysedf1+Hql3dr7o3XX14PYPIHgOK76TUhokUQia7cU05W3aGO1o1IZlszFH8vGHCyfCkAmpWM4VkSO5sDFMo0GCM5yE3zxJSQWMB2+ErJpyzIRb1okzb3ITTarlvAk//qWdaGIkO1YnOUDEDH56GoCM4NUw66Sqa59ymcFylHkBCuWsEObPMOUFRQf/CqZpoeJpHaApRBQX1tgLl3GacUMHG6gkOnFh2aBxJNCZMM26+eeiQmHaGjA4RMUmTJxw8dLCOUtMO2ZFolohnRo9+LAxdz5dPWWa0khCS88A1xzEQTPmxlY+2/uP57yuzxoOOwJKkP5KIELlZ3mlYNr/d1jIohklrENAB4mcEbmInzC7OHSMjkQFshIVQ6LyGa+ZdYKBQDMiYizwIHAuzHh9nMxDpgTjiglmGmNPOYPspS/jYbhrVTqGV0+aVvO1o/yixxyLWIDxkdRWCkQCQohkRhe7//97wgd1JI3z8kUYRvjWNJ80HzAoukArVBwlSo+AoZVHQ+VJVSzQ10clDNJekE6+UgIl176m9t/azSU2yuuK456HH/jBjB+1AYunQgAnRAolEos6bBCIoIZAFo0qIdEsKjWlXYRmmW6bVbNMd+k+RVRKNyGCSCCIqEiFkWgCwtTEBj8Av8fz8nj6m+9Pji9nxpNVruzP97vf/e4999xz/udxPzfEI0vVmmhujSWbEgSejfEyz5ijTH/Ij8eKeXJDpEJKlYYmyCTNgtYxv2gJiZZnFwPIl3NLLIjFlUkb5HIrRabE/6eh0FAsQVMhs1jKzJeXlhqKOWAQoeEKTlWW2dSExMPIYjFXyi/GS8U4PGe/2YV8tqFYWMnlG/KZ0tLiSnGpXFwEuHkUL+EiJFhTqSHR1NIVT/c0tqZXtu/e9uvfxpLtyDTLgzxxNnRNtRU4CMUcZq+cR/oTyHIFltGbJMmyxnIru4CLA5jEm9bFKuxI8ISwUiPC2gbEI24+WqmCuNBFF+Sf2BBRhjL8jUKuXCoWC7mGXGGZZMhyPsaqUeH8Yml+IftkOjY1RfatFGeUWDabTaXSoAfDrkbjwDG3mqiptb25/YVIGZECfko0mrygDzKYVHiK8IG8PMBcSAek8rwdBeCNKzTzVyY2EZOKJ8ptDS10WknGGEK6oTwFulBiFGQeuI1ziTcyHI4H3jZO4jPxEO3oGT6U8otR6lD2hnpJjgwT0BD6M4oTZJYMjUQgd+rmE63mCasfUT4xRIXxy4wsGYhH6xImlajyPBYnXkynUpY4XhUPKK5WShpRDCosPaKZH6oU5jCEXImyknqFbAt1SuWZUpEywsqXUqcb200Pkp20MAOOMVxD1YgFOzvTdDDY1RZPP53u7u5mSWi88z28m/c0KozFEExAC1IFEcpWmasuv4q5aYTH0aqwVkk6y4PHlvFo3boW9aEwJk9V1CKrrIwwV4o4J+5OPZ7q6+2TL+KI9lDd2dlJyC7KFAZbsX23ShUK1Uuku7rL/hsvTAqmpqZ2vbiLdkc0nZ69YG+KB7Vn1fWnKY5u3J/Jicl0ZzoGMXL3fvRsxUapObRVXOLebYW7qptbfJhlpFgFZRgbG2PPlXYxnPbHJcbpOhO7xZh2cqFI5yjR0QQ6l6WFwpEF4AyEoaLoCRqpcXp7fzY4OCgkdqzJFwqjo9+3kl3QE9BDFPC+kwQmRpIYBQdQNIkC2vN5xhEFWfQSCnhKC3UGo8JipZFY40jn4kTNRPtSx/b2dg53aFAojYNC4dYIcOcs+Vx+avwROT49WD3dYj5SZiEjGYLTo8ePn0AoRNixBnCeSEAH07d2dLQ3NTVDVWNUBAtc9bpKOGZ4PBeCj26txXE6R1ku409XnhrRCmwZPxRoyt69e+1lkWIdDJicXFJx2+WESsXe1VAUxrc+rhSKhbaWJDtltK0SDf9sRKMMjlafiDldcbqoF20DJdnIEjJFyWaRpmwmw/lbhtuFhYXNmzcPDv6iJh4oh4Pc923oh9Me8jBIbW2tNred/N25c4ehkTnb90h8TcnyUCOtZ9mQSFVCz4BMQQvLVmafEfAfECcSoR0d6/v6+hA5bml0cmK8kDWBaHrGjUcm0yh1V1dXza1E9/nJZnM44hDE9LJk5DaZnls6qwW1kxxDoVk+k2xdq/Fe4kFd0zokpQLOdKzv4P3nxEN8QpdtLIO8gYEBB7pOauvcurq8Do/rHvVjFvtduHDh8OHDMGVpKbN+fQqm+LNxRI2dou6Kol3Bp7Lu7JSmdwrg6s76uBa5k2p0iqH94QT59u3/cuYiOAYldaCxKh7yp5nOhnAwMjIycunSV8gWOrZ7927OQRjacMMZMIdiYUXkAv8zMzO7du2ydhU78F5YWLxz5ztmgXptEZwKHZq4TQDIO1Ww6Wdn527dusVZ6unTp6l/8cWF0H/SuPBjenrm4cOH9+7du3379tDQ0I0bN65du3b16tWvogJq8BZkwYLr1/+t7bZJbNLLly8PDr7OFHv27GZYIRvUM19oXLwIVnsg/f2bEO50Os3tyZMnPvnkbxx/bNmyRWgNEdggTBr8aIkKfoK5nbqih9ggTQH1dLDxTY7lf4+NPfz4479ykMV0dBBIMILRZCkEV7yoAaqYfpbL0tFXzvauX78O0dJ9Ktu2bWNcbaCoMWvs1FGcA17dXDbRo0ePPvjgT3jFLEAErFAUSjmZ1phrkY6JQKBnZ2fRS8QA1nLrpMidBNsBg2sRhjqkMnHngIsIBbUL011sIOn60OiGxtk7pWaKu7o6e3t7P/vsH59//q8rV64w+vHjxx0LQ4102OJUPJ/Pyfq6IkkbGNgDzIWLwYCzAyVE0ZbnOe2BU0R3vf32yXff/c077/zq6NGjBw4cSKVSPPL0+Xet3VZiSh+zRcp5VPvQ0C3QyeFBc0szgLNcXHa+h/C8UD23+VkXL166f/8+PgNMmp+fO3Xq1NatW5lPE7v+qthG0S1wuSqGLJzi/Pnzd+/ePXv2LAo3NHQTgFL/QGwSc7OzEmuVZOi6GTMcdj548ADMOnPm90hbW1sbt+fP/5Nb6BCfZCzkGEETn5jMzTHRzPz8vALvI0eO8CWB2Tx50rw1PDyMwrz66r6LFy9i3Q4ePNjT0y2irYBLY9+PiEHPEa2tqA4FtdH4ND09PZs2bZK2bd++HdLHx8dhNmbi3LlzNCtc4ArO4GdjePm+iEVyCwhKTI2/ZpMBbIwIhH744Z+//PICXHcbpRWSGpRqip410QPhsRb8fRwA1grq6U3WgB2BaNCUDZWoWT7A1NGKiWN4kgYc4Sf29fUyLAqzf//+/v5+ZnGoYujkxKNmKdvEbBAcZSvx9YhmhofvI+U4wdoypqx2jGivBiJzzuA9K+Qrjh07dgj+X4wKlNlbHtYc0XLbMWeuN3eyDmwxoIF9ZjJY+8YbR0FAdtw0Zi0M8RiqA+OZ2Y6ODm6nph6/9NKAta/FvKRkKRg5qRcymQx7G87BVYxW7ufQoUPhphsm1HTr3DhmO9SBXQLCCFgOHnwdw2Ht6madGQMdpU4ALCKNlSF6lKu8jlWxdu5odaUa7yz+w4sngIjC9SIb9eabv/z007/zfRLGH9IxAgQySCBFEyE/SCOGZt++n+/c+QLDaLgQpzU3l7hDdccDVywKpDAN/CP4I6mA9WLf7BqlOIpaP2Dy1lsn+FDwo4/+gsXm+w1YjkuILwpuKgPBpHwoiaLv3Llz48YN9pUbHZ6DPEV1ajFsJn/wzTf/AZcR6Cimwl/TN6hkiykZfkWo8huEWGgFnclskADfsGEDsIhc0agPUxV6aZ2gGIAIm8WUsJjTK64L8iwcUUnyVFnXUIFoQVdeeWUvpoElcuUdTcl6eAROoZQMh1BypbFmCEixusMvq1f5Dl5QTWxCRYw5PLeTxY0bN9b/SNomMDrWSoE6l7Cu1PkoTkSvBP2T2hFsnnvBvE3XuLYT5zuEfWy7kXLqiuEtjA+11upySrWHwSSBcSGsgELHpLofeoftduvjWTM0lhIiAAPIoArtpJeSQUiWpXWiqK8M1CCWJ06cQA7d5CIaheW723aSmZrABcbGb2GzmT0DQSoq+q4aIKEuZSd6NUZyRTWPHTtmI9hmUgzIw32WH/bDdyqBTNNJcgMOuCD85s2bOBj6vtuyKloruEtFG63FcAFhAArlbfjFDXIaRk9na8JshgPcIO0bsUZenmJEcRRcXFiYd4l4gj88O2W0NIoqFMFIfSsjdKspacCRxIMGxrev86FEtBrpYGjtz+t5RiBJRAknwhVjq7S2OuG6q7in1bJuG2v/eSAmyGIHYrbMqugD0dCsvJ4nuru7C2HQwVzg4lD83HbrKnWKBnTQC8y70TQ1pRrmlV0wjyipB8TAo6OjPGAs9YyumoxLDfyvzpOvUfH4A3Gy4ZBuaqqrxK85KoShepqMouAieuUSkJwnjIz8T56u8hUmGFSqIa82/NWueFyXr4tAUrEUReRK5LI/lImJydde20+IRIemZpnxko2QFFdSqfU4G+CUvGQ3h0vMGf5XnTnEwF0pqMpaR3g4AiSZ6idjJd+CXSUerE9SPdiLl1/eSwQ/PT3NI1gOqBEek03FLeEWCnmNVTGQsuX6GIpueJ4UrSLykCpnQnABny6VwhVNKRwGe5S31owQzC1EK2OmpRqJob1kW2SYePosUsRR0ygEqoiaOKeB8N1w2ZL8iYrGkroYXwODXwHvfFRwAInD8YnJ8eF8Tk5OPHnyFAPOmnNRYeVSLJ1eo1EwnimIiNPpTgSaOi1sCAuGC2fff//MH/743nu/Y/HMzolGJvSencrXB7U65t1ES2htJ/tcJVfUFRZQWCTbyfkLFT6MxxHHwybshYkce3773beTE+PI7NdfX0PQ6S9OO2DyQGsHe9VFj5zP5IfyClq70emPJVLYH/aN1RKr4wbzyBPtHbS6JUyN1ule/123SFdCnTb36/9xxMy2TYkGpQAAAABJRU5ErkJggg==",
+
     "version": "1.5.3",
+
     "updated": "2026-03-06T08:00:00Z",
+
     "home": "https://github.com/sethyuan/orca-simple-task",
+
     "zip": "https://github.com/sethyuan/orca-simple-task/releases/download/v1.5.3/simple-task-v1.5.3.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "简单任务",
+
         "description": "帮助你使用虎鲸笔记的标签系统快速创建任务的插件。",
+
         "category": "效率工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "table-layout",
+
     "name": "Table Layout",
+
     "description": "An Orca Note plugin that formats table blocks for complex layouts.",
+
     "category": "Visualization",
+
     "icon_svg": "<svg width=\"64\" height=\"64\" viewBox=\"0 0 64 64\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"8\" y=\"8\" width=\"48\" height=\"48\" rx=\"6\" fill=\"#4A90E2\" fill-opacity=\"0.1\" stroke=\"#4A90E2\" stroke-width=\"2\"/><rect x=\"16\" y=\"18\" width=\"14\" height=\"10\" rx=\"2\" fill=\"#4A90E2\"/><rect x=\"34\" y=\"18\" width=\"14\" height=\"10\" rx=\"2\" fill=\"#4A90E2\" fill-opacity=\"0.6\"/><rect x=\"16\" y=\"32\" width=\"14\" height=\"10\" rx=\"2\" fill=\"#4A90E2\" fill-opacity=\"0.6\"/><rect x=\"34\" y=\"32\" width=\"14\" height=\"10\" rx=\"2\" fill=\"#4A90E2\"/><rect x=\"16\" y=\"46\" width=\"14\" height=\"10\" rx=\"2\" fill=\"#4A90E2\" fill-opacity=\"0.8\"/><rect x=\"34\" y=\"46\" width=\"14\" height=\"10\" rx=\"2\" fill=\"#4A90E2\" fill-opacity=\"0.4\"/></svg>",
+
     "version": "0.1.0",
+
     "updated": "2026-03-06T08:00:00Z",
+
     "home": "https://github.com/sethyuan/orcanote-table-layout",
+
     "zip": "https://github.com/sethyuan/orcanote-table-layout/releases/download/v0.1.0/table-layout-v0.1.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "表格布局",
+
         "description": "为复杂布局格式化表格块的虎鲸笔记插件。",
+
         "category": "可视化"
+
       }
+
     }
+
   },
+
   {
+
     "author": "sethyuan",
+
     "id": "task-confetti",
+
     "name": "Task Confetti",
+
     "description": "Celebrates task completion with confetti.",
+
     "category": "Visualization",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" width=\"64\" height=\"64\"><defs><linearGradient id=\"checkGradient\" x1=\"0%\" y1=\"0%\" x2=\"100%\" y2=\"100%\"><stop offset=\"0%\" style=\"stop-color:#4ade80;stop-opacity:1\" /><stop offset=\"100%\" style=\"stop-color:#22c55e;stop-opacity:1\" /></linearGradient></defs><circle cx=\"32\" cy=\"32\" r=\"30\" fill=\"#f0fdf4\" stroke=\"#86efac\" stroke-width=\"2\"/><path d=\"M18 32 L28 42 L46 24\" stroke=\"url(#checkGradient)\" stroke-width=\"5\" stroke-linecap=\"round\" stroke-linejoin=\"round\" fill=\"none\"/><circle cx=\"12\" cy=\"14\" r=\"3\" fill=\"#ef4444\"/><circle cx=\"8\" cy=\"20\" r=\"2\" fill=\"#f59e0b\"/><circle cx=\"16\" cy=\"10\" r=\"2.5\" fill=\"#8b5cf6\"/><rect x=\"50\" y=\"12\" width=\"5\" height=\"3\" rx=\"1\" fill=\"#06b6d4\" transform=\"rotate(30 52 13.5)\"/><rect x=\"54\" y=\"18\" width=\"4\" height=\"4\" rx=\"0.5\" fill=\"#ec4899\" transform=\"rotate(45 56 20)\"/><circle cx=\"48\" cy=\"8\" r=\"2\" fill=\"#10b981\"/><polygon points=\"10,48 12,52 8,52\" fill=\"#f97316\"/><circle cx=\"14\" cy=\"54\" r=\"2\" fill=\"#6366f1\"/><rect x=\"50\" y=\"48\" width=\"4\" height=\"4\" rx=\"0.5\" fill=\"#eab308\" transform=\"rotate(-15 52 50)\"/><circle cx=\"54\" cy=\"44\" r=\"2\" fill=\"#14b8a6\"/><polygon points=\"56,52 58,56 54,56\" fill=\"#f43f5e\"/><g fill=\"#fbbf24\"><path d=\"M20 8 L21 10 L23 11 L21 12 L20 14 L19 12 L17 11 L19 10 Z\"/><path d=\"M44 10 L45 12 L47 13 L45 14 L44 16 L43 14 L41 13 L43 12 Z\"/><path d=\"M8 40 L9 42 L11 43 L9 44 L8 46 L7 44 L5 43 L7 42 Z\"/><path d=\"M56 34 L57 36 L59 37 L57 38 L56 40 L55 38 L53 37 L55 36 Z\"/></g></svg>",
+
     "version": "0.2.0",
+
     "updated": "2026-06-20T06:25:00Z",
+
     "home": "https://github.com/sethyuan/task-confetti",
+
     "zip": "https://github.com/sethyuan/task-confetti/releases/download/v0.2.0/task-confetti-v0.2.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "任务仪式",
+
         "description": "任务完成时播放五彩纸屑特效。",
+
         "category": "可视化"
+
       }
+
     }
+
   },
+
   {
+
     "author": "leommjj",
+
     "id": "mcard",
+
     "name": "Mcard",
+
     "description": "A flomo-inspired card-style note-taking plugin for Orca Note, with tag management, parent-child card linking, and daily review.",
+
     "category": "Productivity",
+
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" width=\"64\" height=\"64\"><rect width=\"64\" height=\"64\" rx=\"14\" fill=\"#4A90D9\"/><rect x=\"12\" y=\"10\" width=\"40\" height=\"44\" rx=\"6\" fill=\"#fff\" opacity=\"0.95\"/><rect x=\"18\" y=\"18\" width=\"28\" height=\"3\" rx=\"1.5\" fill=\"#4A90D9\" opacity=\"0.7\"/><rect x=\"18\" y=\"26\" width=\"20\" height=\"2\" rx=\"1\" fill=\"#8AB4E0\" opacity=\"0.6\"/><rect x=\"18\" y=\"32\" width=\"24\" height=\"2\" rx=\"1\" fill=\"#8AB4E0\" opacity=\"0.6\"/><rect x=\"18\" y=\"38\" width=\"16\" height=\"2\" rx=\"1\" fill=\"#8AB4E0\" opacity=\"0.6\"/></svg>",
+
     "version": "1.0.0",
+
     "updated": "2026-06-23T10:00:00Z",
+
     "home": "https://github.com/leommjj/orca-plugin-mcard",
+
     "zip": "https://github.com/leommjj/orca-plugin-mcard/releases/download/v1.0.0/orca-plugin-mcard-v1.0.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "Mcard",
+
         "description": "受 flomo 启发的虎鲸笔记卡片式记录插件，支持标签管理、父子卡片关联和每日回顾。",
+
         "category": "效率工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "lioyeah",
+
     "id": "tokyo-night-orca-theme",
+
     "name": "tokyo night theme for orca",
+
     "description": "Brings the classic Tokyo Night color scheme to your Orca Notes experience.",
+
     "category": "Theme",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQCAMAAAC3Ycb+AAAC91BMVEUAAAAcHBwVFR4UFB0UFB0VFR0VFR4VFR0VFR4TExwVFR4VFR0XFxsTEx8UFB4VFR0VFR0UFBwUFB0UHCMPXE4NgmgUJSkKp4EIwpQSOTcPalgMjnAJuI0IvZAMiGwQVkoTKy0VGCEKqoMLk3QIwJMQUkcKon4RQz0PYVIObFkLnnsJrocJs4oLl3cRR0ANfmUUICUPaFYPZlUPZ1YTNjQNe2MOdWAOcVwPZFQSPzsRS0MRT0UOd2ETMDA4RmtQZ55NZJkcHy5nh895ofdlhcwmLUNBUn1WcKxvk+Jzmepyl+dtkN1ZdLJMY5ckKT5TbKY7SnAoL0d1nO8uOFR3n/Q0QWJee7xKYJJFWYhDVoJHW4tqjNY9TXYZGiUcHCgfIzRJXY4jJDB2e5eiqtAoKDastNzAyfWEiqq6wu0XFiArNE4xPVwiJzligcVRaqKPlbhiZn9GSVw4Okp+hKKxueItLz08Pk+2vuhRVGm+x/JfY3txdZF7gJ4aGCKJkLCTmb0iIC+gqM2nrtUwMkBDRlhbXnZscIt3fJofHysmJDQqLDlJP2JsW5BwXpVQRGs0Lkc9NlMwK0KWfci6mveih9hhUoKNdrywkuq0lfCcgdB2Y55LQWV/aqmEbrAsKD25mfVdT325mfa4mPSAhqWRecFoWIt5ZaGnit5ZS3ezu+U1N0ZEO1xTR3CJc7dyYJlkaIKsj+Wbosd7Z6RmVog5Mk5gZHwhGyM3JixAJzNCKDROLTonHiVyPUywV2vhbIP3do7PZXqdT2FcM0FAQlQtICikUmXzdIxXMT9tOkrucoqOSVq2Wm3qcIepVGd4QE9HKjfJYnf1dY1XW3GVTF2GRlYyJCi+XXHDYHTcaoBJS19LTWGAQ1PmboZoOUdSLzxiNkRobYdeQDOOXEKzcUzNgVTVhVbAeVCmaUiKWkFQNy+4dE77nGL/nmPxll98UTxqRjdHMi3tk132mWBBLyuhZ0dzTDnkjluqbEqSXkOWncCZYkXdillKNC6bmePDAAAAE3RSTlMADVSKstbt+v8fds43KIdG8ViJfpHAxgAAGcJJREFUeAHs09eVhDAUBNEWCNR4ZvPPdb33btD7qJtCndJ7UtPmri/GmZS+y22T9C3DOBmHmMZBX5mzcaA86zNL9sGQF30krcU4XFmT3jVMRhXToHdsu1HJvumNUzGqKac3PYyqXhXZiqtC2fTMsLsy7IMepcnVYUp6sBoBrLq3FCOAsuhONkLIujUbQcwMEnCRwQhjkDQaYYySJiOMSUpGIEmNEUij1oHgQtmBIKtzIOjUOxD0Kg4ERQ4FBCEICEIQEIQgIAhBQBCCgCCRXLFrH4upAlEYx7dnT/sIQxm7lDQ7yvu/1vUo8YoMaUQikd8ux+6fGtF0w9C1PxRE06jNTAt7lvkHgtgPjiWw51qeH1BLeTjw2h5E6j0U9G1qpQEO3JYHsXu41AX5xSDDAS6NqJ0cHDitDjLOe1jGw2QymRqhC/jUTkGEvShocxAtBktseiMfnzS6HTIY+w9P9DnPL47z+kxtDjIDc+hmJWD3c2JoYc816TZ0QZ5vawXpgszBFnRTuiDTLkgXpAvSBbnjILa+NJ5W642kd8jx1LGE6wrLmY4lFck0Z4GlZ0yqR9suklgMRK+/TCV9xEynT8ZiOgxuJEhqsED1qB2dGwFwiWW7GDmx0qiCuYxxRiyy8uGfmk1F5fv6VC0wXPwnloq8KfbWtCf9BG+SzU0EmYLNPxcEkijwcK6XkYp8cHHJMD8XRKsTZDpAkdDVQVZE5Ec4t7pikHF6NAHz0v+yOkFM8gWKYpPKzBAKYvuZIBF9P8hzH2WGVAV5IrN054frBYlQRa8TJNuBxd508vIUVf5cFPRODUZJGA2QM+hES3ICLPlv+f0gWoKj0WI9eX2ycGSognjzCCzcva5X/QHYIPuFIJs6QULsjVJJTE5xEJS+QAsH8UtGTBsf9yeh/OZR1vOJ/m4QA8X/pNp5oLUiSC/mAsuADrJenq75IM81gjB3cvkFTCp+tthpdCL9HiKz/mGv/16QtLwrWKqW/BS5MKA32YAH4mpBvOQoXy2TE4fqBRF26X6e+nvRqUBObbpuEKlayj0wRxnEkKWlKLv2Udau9H3XCyLm5RVxREVW1SHLlYMMwWKNzpkuWKYIYiieOW1bkK1i4xSpVhBLNh4kUW5Al+XFIwUbSTpng/ktCyKo6EkxdPJyTQcxwQbPVGSDWeUgE9XDJy0PsioPNZdnsWw8yBCsT5cEmPlREPkngkzLww2YQY0H2VXsuhKw9KMg9CeCPJSHazC/+SAJ2JAuLcBmHwYZ/IUgk/JwATZvPkiv4hLANdjiwyDijwZxwJ6bDyIqTiR0MO9ugyRg1HwQHJgVD3HuO4j4tSDlVXMLltx3kEG3htzYPkT+1j4koEuTO9+HLMCC5oNYFUdZL2Cruw2yBhvTZwXT6GeC9CvOQwww/W6DjMFe6QvS5CeCLCsuHwjB7LsNormFg5rP2fxAkFR9GbN0eezKuw1CfbCAvqFWkOcB9lyNisZ5p3YF2VBBWifIFmzReBDqK2/zwLatCfKq2BUGcZ0gMuLhwG48SArWk8SKv5VHsjVB/PLynEWoE4R8sChoOghZYEs6o43AdGpNkA2YMOlkK1AvCPXB4qzpIOPSVSfPCVhI7QkiXbBR8BaoD9QNYvZ4/EJNB6ElDsJUHnPoMZgIWhSEFjgYeJNtqi96YCOrVhAKImBNP2YoTlwwV7wZ0jnp4MgNPcMZDfI/NtSmIKbApdDs1wtCZvJKtWjl1ULJpwJpoCTeUKuCUDpA0ZNGXs0grPkgzI9R5JjUsiA0jnEmHPPDfjsIfTcIaWsLJ65nE91UkM2EmfQubWbhKDY2xGx+1IbODXmkU9E8H16XFlTSSCHTl16S9I3po0YqwYTNqUgvDWsHqcEcD3V9m1HnRoJ0uiBdkE4XpAvS6YJ0QTpdkE4X5B+79rmdKBsEcPzr3AY3IsIEBUVEmiIibiNre7f33stVvwxpUiyckCxPwu9Tztj559BzcQ2+2eDqIFUhiBg5Em5AEKnVPpKVTldUew0NWNXGWJ/1IJwu4iaZHwCTDIwZjAeRREwzgUWchTGL7SC2gWkisMnBmMN0ENPCmKwOR+64qXqIOAE2aTJGZI3lIH4XyZEJZ6Z2ewqMCmaOMwuA5SAuEoeDWjWCiBixAqhVI4hQra0guXP33r27d25rEAkJD9Vx/0EYeXD/lgYZIBlDdRyHseM6SEU8DGMP6yAVEZ6qg5RJ02d8czQZzCsZZL7QZ02+OdIHHOzlL90eP3RtoSJB7D5ZQYKkkCFsWkcTGchq1sVTsutfQ5CpktKAHcy2gWeU/gKylkqkFaezHQtPWOqiEkHGSAZ5r2pmD2g4AIG3cIOnXX0QAVN02EpzMMnRIM3GyJD+8HCDNbrCIAvzxARJ37ywukyQAOwOJnWFKgVpGJhmNHKD8CComOJeXZAubjO5TBBpiMRweqNh+zRNv0JBWucVPNGzUj85GUSVuki8/2Zjfo0xS/sHQczLBFljxNN9IH4PibW66iDz1Tl3ZxAbY8ZQOtm2/2dhbJnzNK+DiNZ/EsQWXST//YMgwiWCEGvEpS6ptsoPspW+K8hKQbIO4IzkIZGFbBAiShfPjNt1riyII57oIPHEc2u4XBDFzDyvXZUgKpIjHy4EXSS93CCqn3mxVnaQtGZmeV8uiLGATTJGxIoEkZAYK9hkngyFnCAqBxsmSGzWgug511S7FQnyH5Jh7mXfVjaI58OmBRKdsSBK3jJQqhGEU5Cscjf06+yoBQnByZDxIMPiQR49fvL06ZPHj0oPYiI5gpSphRFrui+IfyOCjFPD8hQPMsrZfBMRibkvCNRBSg6iImlsud2xtTeIdROCtCoURESy2PILe3uDKHWQcoN0kEhbTqe06yDXHcRCstryErUOct1BMCZAWgOJU5UgdRC9DrLb/WcPnh+/KD+IsWWVNalXWTu9fB5GXj0pPUh350adv0VB1lDA6zdh7M3bsoOskSy3LAL3FgUZwcHm78Jz7z+UG6SP+UvUOQl1i4Is4FDTj+GGT59LDTLZckFZRiLcniCWDwe6/yVM+PqtzCASki6kaEhEYCuICQl2kSBHBTbnKa++lxgEPCSL3B/oMhPEzTklF8hFgvQP3Zw/DDPe/CgxyAiJCgm+jBErYCbIJLvsVx4WCeLCIeY/w1y/5qUFEYyc/awekv+AmSAmko4A55YyFgpiF9ucp336XVYQGCFRBpn/NyVgJ4hvIHEEOCGpiMWCLGC/P1/Crb7+LSuILyIxWhycEHiM6cBOEOhjTOH15bIxFJF4XoEgGux152u4w/MDigjKCQOJseW2a62DMfm/ydK0W6qBsSawFGRlYJoYOAWCBLDXr3CnY9iLw3w6JEgyZjWBqSDQsDCpPYV2gSBT2OtruNMr2O+wIBA4mKLowFiQ1A3t3hIA+HKDvAp3KysIaXi4weIDqFSQ5ZgEsJMwk/GEoS7nEDHHkSVsmtDIhaRFNPOvJcgq3xSyFsO1gqSrTgTIoY3JApLceFhKkBJo9sR19QEHJSg/SHHT1Srw/2fnvvYURaIAjN+el4RNk+pmc95ldvJA2zbhgCCGdhxtdBUGwwMuRSdDAbIGqGn+d53D98NTxOqJcnsH4UAVpABVEE5VQUjtvH4hfCZBFFVTdYXrILKBEVPhP4hiNWyMOU23JfMapI2xDu9Bup1LXOW0VT6DOBhzOA/Sc3CTBif1OL3HM9gN+YCxPtdBiItbTAIn9TE9yHewowHGBlwH6eE1u+GeD+tXDQ8RR3BaZ+PUDeRf2JFqY8TWeQ7SdZBqTgjc+Grqi3Biv3z3R1KOP/5h9mB7FBhGXQGegwRINQQomCRHPq23+CRHJMiN6yAhRvqPoFjsWfIRqIcVRCnVFPxmPcg3DzCIipQLpSD8sTE+hIcaZAil8OOTDT9WQQr1djPI2ypIoX7aDPJ3FWTLI40SYY2oUV1YpWoRuKZbHcMzDRHymW0GmUE+knZNgTREG3YM0zONtqURYHix8j3EWjAwvebg6kIsR5AhUirrqwJY1bw9qieNmv/zCIa8BXIaYGwKyV6ch3gvPH8BW2oYsSCizx28ZS8k7oKgCFAz8YYFJ2dlBSEjG9fZI3aQOoB81cdVA/F4QRbBtTZSc+1ed58gijDHOzqcnJoRRGrjtrbECjIHLcQNneMF8TDJaJ8gmoGRvt+bqNoFgZMjTmoQycdrXqc+dP0Qr3UII0jnoo8RL2gtl5OFh7FJAUG0fYKENIerQGGmqUHqGDM0AhSpNTG2YASxLxHRbBGIidcpGwUEEfcIQnlLKNAyLYiGsXMCt4Q2Un19OwgVCHBLtjHiSMcK0hteM5Byh3cs2C9I8wUUSU8JQppIXcEK0kDKZwW5HMEKF6nlsVdZAev/vUcQM28PIu+IwC6UlCA1pDwRVj1ykNIZQXqwqoVUi7MgfRVyec06McX2x3evIZucEsRnLVpgjlR9O0iHte2NOAti5+zx25McftuhiJgcRO5jxBGZU8fcDtKDNS+Q6n3eQZ4/yeU5ZJKSg7TY6yRiI6VkBSEPIcg4X5AxZCLJQepILRIOt9SygsBDCPIkn98gW3KQRsJUniNlZQZxqiCHDWIm/KkWUm5mELsKctggNlJd2DRCqnPqIFUQjCkJR1v8YoJUQeSE1degClJtISzVDIFeNUPKuMqqV0EiP+cL8vMR90NGVZDI03xBnu516CRI2FM3kNKqICn3hbCNzyCTkBzkAqkO+1iWI/AVZHmcIHD2dOck46dn+x1+/+oDRmyBeRqxAXwFmcAaKzlIodJPUA2QajFHyJSbIBbjvMykX9ogekqQC6SaBFZ1+xgJBW6CMF55Ww6WNsgyJQjxtsc6GSBlATdBVNw4NSsGiOUNMkkOwjpXLnSQMiV+ghAPqXBCgFIWIZY5yBSphXpLZj3pwV9CTGqZSDkq8BMEFnjN6wRBu/kBqbZR0iDSeR/XTGGVOFj5Y9yGjbHLGvAURDRxk0v8Ugahun5KEJB93OLUgKsg0A1xjT0FaB82yFkGyGNqJwcBYjm4zugCZ0FAaeA9p/4CAOoHDfLLkwy/QB6KkRSEUuoh3hvUCJQqiKJSAqRbuiZSoT8V779MgVVdNaIf5t7Cfe81VBKG+jVJW7SNptccuNNHwCKr1AtYp8fvzBnkeERF11/AcTzPviCLTzQIh8j4P/btak9tLQrA+O16yDrDLrmpe5up62v0qsc1gWTIItjgUixFz6McFjISwhBnmOR/h8uHbPmFbfCYC4P46Ce20b0wiI/+ZRv9Hgbx0W220csgBhHEeEKSRB58xsfYRrHLAQsiHyQVXEipaQ58lGEmvAtUkGwuj6coh+CfD8yEG0EKUiiingj+ec1MiAQoSAlXlME/15kpe4EJcoAzlWrtUKpL6ZraaGIa/POEmfI9KEGyRSQt4cRZBxz45ysz5WZQgrSQlGBbuAfMlMdcQIIoOFXhYVvuMZMeBSNIFkkStuYDM+l5MILEkbRga14zkyJBCtKGbfnMTNsLg/jgOzPtfRjEB/vMtNvgIlmMd4SLE4SPkyw4djnGTItdAXfUS40ikkq3LYIBIT4lwwwvtcuNVK/cSvPnI0hNI6JHQ4EfzII+uCGdwpO6EqxI49QAprKtCi4Na9x5CNJGEvcoyH1mwVdwTk6insobBikBCK08nlQWvAtSa8+pSLrtY5KPQThrR1Bx4JSo4aqGbBREhbqGOjnvgmi4zsjHIBlmSQYcymo4U8wVxtL4oFpcFOENgiQneZxS1NFYmpQUnJG2ECThY5AbzJIb4AzXxdMrqUILZ1SDIJUmImojDmaELpLyFoII3gXZ+0knyiyJ/qSzZ2enoTmBYyOckVaDEFWAJbmCU0XOqyDt1lwKSbV1pA1eBXkUYa6LPALzhCGSgcH2XM8wSA1OUJEkvB5ltVbfb4+C/BRjHoj9BKbVkKQ4OIlXkNR1QVbLTZBMLk6QfeaJfTAtZfiWDpCoq0HKRq+5cHGCRJknomBWBw23fkQkymqQGpwiI6ldnCCPmSceg1mFNVs/ChJxUxDO5SBhEHXNokQZyWRTEHA5SBikhyS95i1obwySdzdIGERbM26tIVE3Bqm4GyQMUkTSWTNdTPodJAyCMzLojZCUtxMkDCKA3gRJ1+8gYZAmkqyJ4XAwgrxhnngDZg2RiGv+1HOBC/KceeK5xZWT+ppXWApckE8R5oHIJzAruWYxqopkFLgg8OnDn9EF5lB04c8P5nvovwm6b048UEF03jGHMmDDGEkPdIQ8Tg253QqScDXIS3/W3HWEIk7lZcNRbw52K4gEp9QcBfmJOfX0C9hQRTKA07pIpJ0JUjP4K5TyjoLcZI7dABvqSIaywQ9ZCnYmyAhJFU44LKKTIHtPmWOxT2BDF0mZg2NZBcnh7gRJIMknYIkvNdFRkOfMBf+BDWIeSVmGpbiGJAm7E4RTkAzTMCPXNERHQT7FmAu+XXFwxPGwHecAgJdyTSSasENBoI1zWq7UVht5JMmG/SAfmCt+d3ZMfl5LKVSDKCLsUhBBQ70cX7Yd5Mo35ooHl8GOWhP1GlnYqSAQH+IpxQOAnO0gvzOX/Au2xHt4SnHAwY4FAbGHx/Jqlm5mN8jlB8wlD3iwR6pWcCk1kAHOVRBRIgKcbZxTkBS7NRlIR5oSwbofr8/CdF6f5S7YxSVGg1KrVEtnwZAsEf2F9dmZ3gSxQRbriQ4H/7NzB7uJAmEAx6/fa3rYiTyA2cOGNGm2m32WfQA4cNQnMOHSk6OCjHyAqmALPWyHWqtA0gnpYIfM7+bBy/fPFwhkkItUgNJ4kM7pIDqIDqKD6CA6iEXni6XnrwJq6yC3D8LWIZ5F69jVQW4ZZLLGqgQkGI0/QyrGn/nXxyCbLVbtLPh65g/y5YaD/gXZR/guinZYOoAED0SCX70LYnpY8hPb4D9tOl/iXokF4X7+7VuQFLmIwQVXkQXhZn0Lsmy+iCuyIHxF+hXEQi4D6R6IJH/6FWSP3FHZBeE3Wj0M8gSyjZ9FkIpnEdMeBgn0sywdRAfRQc4clsRxSgXfgBqOa32fIJbLmXDFiTlXzSBu4OHJdkFNqLODVxsosdwL8VVxePkeQQLk9g3/8pXcEGcV4qUshRr6PhMjKfCD70oM4p7Q1kEKS8UgxhKrfKcxSA7wUuCVzJYXJMNLW+9DKhYkstW8htgRVmV2U5AjBCGWwh2eeKb8IDVUKEhIQdTgURipeBQ2AFE0RCyeEsZovA5PRZyGIOtDGeNIHQCLLbCU3iCILRQklvUpOfmH3OJdYsCbyQpLfkOQMtZxcj2HZfdBQkMkSC73hGcLv0HYpPawG5NaEG5H4czIkLNkBdmwNwvkUna2AYEgLggz70kn7k1oJUeuMBqCRFezmCPHZN/25vV5Nwdpa0Y6MoNWrC1ytB4kZA1rk6geZDQkHRmOoJUAuUV99jlcsZFLFQ9i3JHO3BnQho1cZNSCxE1vjmLFg0xJh6bQSobc5j97d6ycNgwGcHzVS8IAzoc1Qc/EtkMMBFoAvwYbS84DU9Y+ARtMXpprc0lz12sS4Do0jG3vk7FldJX0/V8gw++4yNInOw+EmQDiBKCwwGFlun889mIFSBuU1pZYZ+1yQX7oD7IGxa1Zib4/HnvLBXnSHiRxQXFuUnoQ6sF8EL6HInWb6b9n6mmzC0Xac1a458dj9+aDZHBiQTvbXsbYbm98uc3agfTjIYH4EZxSmi15/vY7X2YpnFLklwR5MB1kdgH5NW+d089DnNsm5HcxK/dP/afhILwPeUUtv+gBld/K/9n1eSmQr7qAvNy/HQ6Hz5W/QcNtOGVODJ2GW/Vrae4O77390gWkXH6UxzEve4Q7zyOJfFY+Q0GcnMVqK5E5U09aOQtoh0D+rJaCqBtfdsjBvwFRaY1J9c00EA8EuatYfuokXrkgyJP9iXwxCqQDggZJNWNAyQAEdZhkz6/mgGwiQIs6vKq5LN4R/Z0NkyzemQEi/qLnaFnloNxyJP4CqGR3JoCIF1hevdrJxbonv9QSpzmI+KMU0br6UdJPkfBDFgRS2wNW1z/HbK/fBax9jUAEO1jp/DzD1vNUvKulG8ju6VhFINwDrH79XNPv9T5geZWKvD69JzOXpb4GYDX4+a4j8ClgTe1+o1xP4jkNAZF9Eu3ZDJJJLK/kQNg6AqTMXhDcIzz/DaoQF7EVpCezi4GDyO/X9OwEkffAQWRFLATh16jHVtWlzy0qcs1tA4kXgBWqu4UbAtYitguk3gasK5XXoq8Aq123CWSYAtZE7T31CWClQ3tAkhFgLbhaEN4CrFFiC4houzVW/SaHWLzZbANI6ALWaKj+1RrDEWC5oQUgfAJowZipB2HjANAm3HiQzQLvIyve4q9Y8T4s8Da6gFAEQiAUgVAEQiAUgRDILFwZXjjTCWQbgPEFW31AxhFYUDTWBmQKVjTVBmQAVjTQBmQPVrQnEAIhEAIhEAIhkP8nAiEQeg6h5xAPrMjTBsQHK/K1AWErsKCVTuch46xheNmYTgx/t0cfxhUCQRAF5/gHO3hQ/sHKe29ZVb1Oof87QggBIYSAEEJACAghBIQQAkIIASGEgBAQQggIIQSEEAJCCAEhUBiJhDojkU6tkUiraiRSdTISOVNjJNKoGIkUaTTSGCUNRhqDpN5Io9eFaiRRdWkykph0pRopVF2bw0ggZt1YjAQW3Sqjcbix6E6/GQfbej2whnGoWPXI7kNh1xN7+DCIXc+smw+CbdUL+tGHwNjrRWUJ/znEUvSaufqPoc56y1T9h1AnvacfRv8JjEOvDynNqbZd+JcguraemqIXnAMYJQwNpR3taQAAAABJRU5ErkJggg==",
+
     "version": "1.1.0",
+
     "updated": "2026-03-17T16:59:00Z",
+
     "home": "https://github.com/lioyeah/tokyo-night-orca-theme",
+
     "zip": "https://github.com/lioyeah/tokyo-night-orca-theme/releases/download/v1.1.0/tokyo-night-orca-theme_v1.1.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "tokyo night 主题",
+
         "description": "将经典的 Tokyo Night 配色方案带入您的 Orca Notes 体验。",
+
         "category": "主题"
+
       }
+
     }
+
   },
+
   {
+
     "author": "lioyeah",
+
     "id": "orca-cn-typography",
+
     "name": "Chinese typography optimization",
+
     "description": "Optimize Chinese typesetting, including adjustments to punctuation, spacing, and font styles.",
+
     "category": "Editing",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAAsTAAALEwEAmpwYAAAEqUlEQVR4nO1bS0gbQRiehtiS0oq20kN9HDxoirUgfYiGnATxVBvbJa2CnrxrD1XQPmgPxR6E9uSjBClsLVlK8SCCL5AeRA+C4OsgpSAo7UnUZi+BKf80s26Tfcxmd5Osm4EP1j8z83//Z+afyewMQgh9RAjFEUJYA8cIoVbknBJKcNaKCWIeRwzBU0wi55QvjDHFEf3DU3gNF9S2pEBWOYqcU6KUt1JMEKssLiRVRJ9xKhwugFJMSf9YxCqA1CBROJkNnmmhNkFmE7LQ3h4BRFEUAMPDw8vUBs/UTm3BYHCP2uA50+0tF6C0tBS3tbUBAYKlpSUcCoUI4JnaqW1oaEiywTO1290eOAJXywVokwWf6wCuhgVAOnCsAPpARywVu7q6sh4YKzo7O1mDP0KJFd5kYuqIJo95AAS/s7MjOYjFYnhxcRHzPJ8TAC7AifLb3t4mnCn//3LCaZwQ832lOVT3Kz8yMmLkK5YRjI6Osg4J/SL+m1JUOwwEAlkPOBnBYFBvaMjXFekLsL+/j71eL3FaX3UZR59VZxXAAbgAp4ODA0sE4GBhIZ9b5YhEIpLqH7orMZ4KZBXvuyslPhMTE4qcIZbEwkm+YlQtpDP5okMOjuMkhz/GbmddgJ/jdyQ+4XBYkTPEYiQHYDUBjo+PcVFREfm8puKiROLl43J8ocDDNFarS33416d7KYGADT5j6QN8vXpSIbUFLmAvLi4mHM0KwKkNgdnZWamjvodlxPmfaAM+7z1nKGF97fenCAA2I32Az5jQQNoCF2qfm5szPQSQWhLs6emRHH1/W0ucz7+ukWx1dXXS3JuM+vp6qR4kr2QBwEY/h7pq/YAPWm/hzU3SFrhQW29vr32zQFVVFXFy5ZIXx781EufPw+WnhBYWVLMwLFhYBYC6av3Mz89L9V6Ey0lb4FJSWEBsfr/ftABYKQdsbGxofiV9Ph8+PDy0XQDwAb60uGxublqfBKenpzWdNjU1aS5Ednd3SWAQ6F7kbtoCAJqbmzW5zMzMmBJAgA0I+e9xOgMMDAwojsuOjg68tramSZpCbTozIsD6+jpub29X5DI4OJgyE0AsiU0VwZKlsGgCVgiQJqxZCotpwqockAkBBKUh4GQBjA4BrLYSNAO6h/eo8SpefncrowJYthQWHZoDjAqA8klQtF4AGAIwTXGBkowPAUv3A0QHJkFL9wNEBwqQE0mQd5AAnNuHAHL7ShC5XQDs9hyA3S6A4PYfQ8jtOQBlQwAKGwI3LICQjSFgpwA5sR/A6wgAG6Vgh3qwgWql7/wsEMqB/QD+rCfBk5MT3NfXZ/ursf7+fuLLTgG4dH4MTU1Nab6ssPLlKPjKuf0AXvYV18KNMh/+rfJ63F/G9nrc6BDJSBLkGae5dGEmR2RkP4DPYQEysh/AywR42nrd8sNQ0KfJWcLeWYBnzAFWwG4BcDpng1dWVrDHw3ZOyAzAx+rqqiFuegclQ3pHZeHsLRw/ZRHB7mOx4EOPx9bWFuHMcFT2AWK4XXXmD0tjtx+XxwDXX5goyF+ZaclfmkL5a3PYvRcnPS6+Oht3++XpMQYRYMGgeMEoRwus8PRuw0HMo38BnulXsB5nNuIAAAAASUVORK5CYII=",
+
     "version": "1.3.0",
+
     "updated": "2026-03-25T15:15:00Z",
+
     "home": "https://github.com/lioyeah/orca-cn-typography",
+
     "zip": "https://github.com/lioyeah/orca-cn-typography/releases/download/v1.3.0/orca-cn-typography_v1.3.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "中文排版优化",
+
         "description": "优化中文排版，包括标点符号、间距和字体样式调整。",
+
         "category": "编辑工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "XxKARLxX",
+
     "id": "oh-StarTrek",
+
     "name": "oh-StarTrek",
+
     "description": "A Star Trek inspired theme for Orca Note with animated starfield canvas, warp jump animations on task completion, and immersive borderless dark UI.",
+
     "category": "Theme",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAADcAAAA3CAYAAACo29JGAAAACXBIWXMAAA7EAAAOxAGVKw4bAAATLUlEQVRogdWad4xcx33HPzPvbW/XG4/HO96JR4pNlCizqdBUsS1XyYZtOI6FGAnsOE5iA0YiBEiQ/1IBx3FFAggGbCmusqPYSSxRpERJliVRpij2673v3vb29s3kj7e3+046SrSlGPYPWOy8efNm5jvzm18dwXoSn/nzv96fTMY/OTM39+nGpmYl0FIIiZAS0KSLFgDN0RBp23DKkSAZ4aUt6MX0eMn5o7UOmwxdKxumt1ZOSE+tHM4mWMqXAQjZBbSyWUnniBiQyBUACIoKSim01ggh6hNGJEzTPBmKxb7yza/8/ZPrwLgfPnb/Z76eSq7+EQgjk8/X6pWQtbI/XJ+4J1Qve6MNzuQamjB9/lq9L9aEME2kYSKlREqBUopCarXef7lMMZkAIB9frNVbxUKtnE8lXfU5lK2QUhAKhWlsiP0wmUrdF4lGH37k29/4+GvAffjjn/rJajz+biElLS0t33jmzPlPx/p2YimBrWy0EOhac4EwJEIaCGmAkCANpGkiDNPZ5WqdEBKkcP4B0Ghd/SmNsm3QCqE12BVUpYy2bdAalI1GgXYmKgAhAK1RGoS2KExdIUSJ3Xv2/jC+tPTBcEPs+Ue/++DBGriP3f/Zf1pZXvyCVbEZn54mcv0RVpcXWb3yEmSXUa79FcLjfnAV62XlCdXb2KV6uc6hBIOBWrmUz9a/VYoNSdc/loZRK8f2HqOhvYPk2afo695Uq3/mif80xEc+8SfbUsnEOaW0d2h0lNi+O0mdOc7y1Eh9wN9icFprZKyT7kN3kz5znL7N3QB0bO66zdh7w4EHspn0ra2tbf+8Gu05nDl3ioXpUaS733XgDPfDhuC04aW7o4n7P/ERjt1xO7t27iAYCtDb10MyleZ973knw8OjxBpi3HrkIMNDw+sm+0bkCDfX/EpZ8stLNO07SmF2mGAwiGGYXnNyeuoLAE89/+IXAv03sLQSRwYa0MWk62uDNyI3OEOVuPe+91IoFfn5C6f54z+8n8FtW/F6fdxx7HbCoQCP/vR/uX7HNmKx6FX7eZ3RXCVnMSqpeYqrCSxLELZsfMXSHbUlCG/ZzvKlX15Dx29MXq+Xvr5eDMNgz64dFAoFPD4vJ556hmy+wPDoBJZl4fP7+cULL70lYwIkh18m0ns9AFrrdnPtheELY2XiAHTE/CwUf/1BypbNw//xQ7Zt68fn9/K1f/smTU0NnH3lAn3Do6TTGaRhEI8nWFpafnOIXKTLOQyvc5alkMJU1dOlbBvsCgALiSyaGm6ErLOB1+dn3/59NDc3MTE+STAUorW1BYDZ2XmElPRs7mJqepbjJ0+xb+8u+np7GB+foJjLc2VomJtuvIFdu3YA0K9smhob8JoeJienmZ2b58Z9ewkE/IyPT9La2sL58xfp69tCIrHKxOg4WruFTn1udsVCK40GtFZ1BNdykAEO3XKYBx74PIuLS2TSacanZ3j/e9/F1OQ0z794hnfedZSVeIJAwM9//fQx/uD3P0o8niCby/HZP/tLpGFwx7Hbefc77uDi5SEuXhnm7ruOEo+vIoAnnnyWD917DxfOX+aFaISPfuQ+vvPdR/jgve/hgQf+dp3UfM3OaaAK3LbtOjgpr+Ugw76b9vLSmZc5fvwUWtsMjY1z6ODNfOmr/05vbw8z8/M888zz3HL4AK1trZw+c5aZ6Tk6OlopWxaqWOJ7jzzKjft28w9f/Bq3HH4b5y9c4crQKLuuH2TLlm6efe4Fvv3QD9jS24NhGvzeR+/jWw99n8nxKQTrNMp6EqK2kUopTNPnc8AZEmGXa+0M06z1YXp9NeQD/X30b+3lpn17efDBb5NIpjClZH5+gbvvPEosEuHe993DmbPn2dLTTUMkzEDfFh7+7o8QhoFhGHR3dZLLF0gkEmzf1k9zLMqx2w7x5NPPcfDgTbQ0NNLa1MSV0Qm6uzoYGhrh8cdPopVCSrle53kce3VLdyezKymEkEjT2bO6whDrdQfAgcOHrVfXWeUyP3vsBAAT0zNsH+gnuZqkkC/Q398LQhIMB5lfXKSzo43tgwNcujJc+wZga38vC4tLgKB7Uxc7dmxjeGySk6d+TmNDA4+fOMU/fvHrdHa0kkql1+1MuLFhw02bnJmnVLZA1tXW64IbHhpa99zW2UFiNcUrFy4BsLCwxJa+HkZGJwiFQ8RiMb71nUdIptLkcgUM0+T4iVM0NzVhK7vWz+C2AYZHxojFYgQCAR478TQ93V10dbajteaJJ0+RK+QZ2NrL937wKLGGGFv7e9FAKpHkaqSV22MQSJ+wCz5hF7QQdYNWa2zbFsuLi17btkW5WGBw+3Y2b+7mjqO38Kef+iQXzl8imUzS1dHBpUtXiARClEtl8rkCFauCBtKpDE/9/DSNjQ00NjZgWxbBYJDGhhjDw2O0t7WSTKU58dRzBENB9uzeSSQS5q/+4vPc84678Hq8vHzmHBMTM+zYPog0DZACG4mNwBYSq1Kp/YSUaCExAmEH3p33fCgPMOffHJg4/vCGK+K2Gnbv24dhGEyMT5DJZBkY6GdxcRGlYdOmLhaWV2hvbyWVzhAJhZidm6e3dzMXzp4HKYk2NrBpUxdTUzP4A36aGhqZmV+gv78PAL/f0VPzCwt0t7XwypURujrascplZqZnqouv0FVPQVn1kyN8AfpufT+R/Dxeq+CAU5G2wHzFz+TjD70huHWmjwCthfNfdUr02gtXmxrbVCtE1QXSiKqEEzX3SQgwTYNgIEAo4Ccc9BOLRgmHw3hMAyEEtm2TTCZZWl4mvpomlXB8Q+EPsfX2DxDOzGCW8pggER4f2MA6c/kq1rlLEDtCSzv/wmANolIuYe2y4KXX5+rGBmEgpMDr8dAQi9DR1saO7YO0tDYRDIYolyxMQ5LPFygWimg0Hq+XSDRKpVzGKmRRqsKFy8M8e/osNgZaSDLRHhqXLmGq6l4I+cbG8VtJXp+f5sYYA31bGOjvZ3PvFryBIKlMjkI2w9TkNItzc7X2tlVGCEm4pQ1jegyAZDJNc1Mjd7/9CBevjBLPOu5VS9CgIgSm1vo3Dm7vzm0MDgzQ2NxMsVhmaWWFpZU4qdUk5VIJ27YRQhCOhGvfWBUb2y5TnJ9DVcp4TYPmlkYQgsdOPkuuUGSN86TPObembWv8ze0Qz2EYLodT1cGuOzcujtMu9eE236S3HghCKYRhEIuGuX7nTrpam5DSIJXOcmXIcYhtl1AIhMK0Vj1qXbGR0iAWjVIp1vXd3NwCAPF4kh179jA2PoXQDg9qrx/D50cIgamUjeH1ArlrXPdfjYKhIFs3d7N5cxepQpm55WogKJ3esH1zZ3ut3NjQuGGbaCRMOuN471NjYwyNTzkvqgtsVBfX1IDh8W7Ux5umjvZWrt/Wj1WuMD09R8mq0NrZwXJ8lVI6icc0iMTqFkcwFnMmH4sRiTYQCPhZmZt/Tb9rwACe/sXpWlmsgTM9gMDU2pFi0hfgGsIXyEisVlaWhfD6kb4AWtnocgFtVxAIOttbOXBgP5fOX6y1ryhFJpvF7/NgtDmsl1ldoLG1DQDbriANA28gRMmyiHglYb9kfm4ehCSbzSGlRCnN1Nw8swvLuCctPAGE6UV6PGitMYUAadR9t1+Foo1NdG/bhWf3jchMnMvPPEMpvoDXNNh7+FbGZmbWtQ+/KqQA4GnswK12FjMVMp4yYSvD6lSSRDKLlAa2UpTKJTKZDMPjk1edkwaEaaC0xnQs7Wtzd9x0YN8edm8fYCJ0PbGjN3OkUfAvS3EWh8DIpyAQcQC1dZBdWrhqP83dPQiguDBB2tPI7mP30NXSwAs/foTichpTQCaTJJ5IkMzkrh4dq5LSIKWBsm1MZTsGrZYSw7WDtosXldZgGBg+P82Njbzj2G0cedseXnzpFbKLc6xMpPFbHspWBTubxq5YnD5xnOv278djmBSzWYrZDKV0GqtYQtkV/IEgAPOry5QqNuFYAzJUYuXyORbzeVamx0jHl1hZcUIfdskdItTryl09PcxNTeFE6DUI6bClUuoNV0N6fXj8fnbu2MF1B44iYs089dwvSSYSlDPzrK4keUKtkhodwiMh3NxE/w030rKlj8XpWaJNzSjAWylD2NFd6XRm3RjZVBJSSWbHhl11q1wLZdckbxW08ycwkQJbvX6IoaWtjSO33c7ggVtRvgCTFy8yPz1HUZkUUsskR4co2Rq/38/uY3ex6cYD+NrayaYy+ComluGhAWgO+8G2mZ50RHcinSZTKNVtTA2hUIhMJg125RrDfJBOJt3Y0EqhAVMrjW1ZqHIJ/PUEhlSKTZ3tNLd1cOjOdxHZ1Et8fpa5y+cYu3gOgFwuy3Iqi60FoYCfm269Hbl9P/GSYvnEk6yODxORFW7cNQjNA0hVJrWSQKMpF7NkSxW0EI4Ir84svVxPhChXIMhwld1b4Q5eKTTCqmBbFlopTGVb2GUXP1dp545tbNlzkIHde8mkM5w7dZyl6QmyyTqrbO3tIZLKMD+/SKFU4OLZl+HsyxTLZbLxZbRd4Z3vurvWPpPJMTMzS3rVUeReKpT0a53kX5dkFbZdsQCNqZW9zicC2DE4wM2HjlBu6WPk3FmSS3NMjY+RSacoFQqYpklnWyvLqQxNDVH6N3eSSKa5MjpJIplGSBBC0tC5mabmplq/IX+AaDRKNLqT1eUFbtiSJysCPH12/C0Bt6bEtVVCq2r0y7bKqIqNqAY0G2MxxscnSF8aIbG8xML8HLn4irM6pmNzplcTBCNRVmMxQiE/bc1N3HboJlZXk1weGSeRytIV9rCtJUhLdy/RSITEaooTyVXae/s5+/Qy2+58P/GeG1j8n8cZe/Yk5dQKuho7BTDWHTmX0NOvdruqZaVRxSx2OeCwJRqKqQTKrptgz718EV+VW7KZNNqqD/hqSqdSpFMpVlbixJNp2lsa2LdzEIADhw7S2t2NIQWZRJyVsVFikQjDF88D4Msl8MxPoGeHq5OzrzbMtZF25mkXi6AVpqqu1EZB2WxihXra7/Upk81TqczT0VI3dr1+H8tTo+RnZymlkyQsxcW5BOlCEatS4fhPfkZXk5/xCQsrtYKuXH0Rr4VqSZFCDuWwpUaXcggVxk4u1RoWhIFRFcXKtaLKNX4hVzdgzUCAO48eZv/bbubSKy8TDAaYHBkBq0yuUMYiQDKfxVaaUi6HEoKiL8rJK/OUVlPVyYEULqn4KmVdR3GVxdYaVIVKvuycOaVsCqtxCPs2/uAayVO1bk6/8CL5TF1BF8r11aiULTwek4ZYmKGxCVbe1IivJa01QisqmUQVnF1dKfvNsUSxWOCJk09jSEk4FCQaiSCFE1yylaZYyGNIk+XECoWShd/rZGjT6bfOj9Ra1XBoZWPaSlEpZFDeZpR0ZXZsV8jMlU01XFJLuQSNUIps2QnHp1IZZnGUsZuBtMvMs3K5+nttb9jGzX7rJIKLRdf1rxVK2dhWCaUqSL322TVmeX6byajmCLRtoZWNrIP63Qe3lrfTto3WYGolUJWK88Kqm2FuqFq42EC4Ew0uvVTZWEe5E4VSGhvW66tIQn0V9lujSCTqGNmuGYHALuYBgVzT/PoN3J7fRloPDDTa8VZxTpmsrYn+3QC3c9dOOjo7N35ZzSOskSm9/kClWIAIKJeGloZno8/R2s1+Gwc0198TcXn0bgvgakr5aoKt2ubChYvrY6Tub4VESknFKoN2JQf0NTqGbwW1t7e9pf1Fo068RgujtghKKy3tUn4UoFIq4G3e/JYOejVaXFx63ff7b97P4PbBa+5vLWQhgzFExRGKGp0zmlvb347W283s4o/N/pu352dHqkpVOedQq/VXol5t79W8aPfP9Q53c1f717EPS6Uy6XSacqlUM9uvpsTXrmUoBG27jlCYG6GsBF4qp00ArawfgxOp9TZ3Y8UnX3XX4zdL8RXH6rymGIrWiEg7AvCHQqzZVcKQ/y1TCfVxAKH1BxIXX6D1hlvxNG/5f5r2r07drmuGG9FaMqb/yD1kxs/X6ou2flAA7Nix995yufx92wwZAN7Bg2QTcVIjZ1GlLEJX0EhnJdexxLpQjatYvUxazZrWW+hawtK5E+qw6Lobf+7wePXiqGkaSMOkUCzWpKMwTJQRoGVTN7HenaQmLhBVOQrZrDZ9xueGL5751/r9km27H6gI39/VkBtBwj3bsbVzcUXXwLhSvUJWfwKkREvDyaS6sqneSLia+5PrPG21LsiqULZyzCa7AkojlO2kpaq3aG1b1caXAEIjUJTmx2rdeNJz2vCYXx25fPZzgL2Oqa+7bvfHLOl7aA3cGoVEfSKmz+foMcODND0YXj+mz4/pD2J4A9Wkih8zEET6gxhen+tqsLMoWmmUqqCsMqpsoYoF7FIBu1TELpVQ5QJ2KU85Fa+NWynUHWP37haMEIHsHNpWOWmafzM0dO5L1Vf2a05sf/+eNsNQn7GU+DDoQdDSYRtRZymhAVm/tyxElbV0VRBW7zQLx9arxlurTWX1JoKqsqWqCa8qw1VvKzj3nJVzIBzJLUAgkAJsDVopLWBamuJH2pZfHhk5P+rG8n84ND7JfvDQUQAAAABJRU5ErkJggg==",
+
     "version": "2.7.0",
+
     "updated": "2026-05-18T17:24:31Z",
+
     "home": "https://github.com/XxKARLxX/oh-StarTrek",
+
     "zip": "https://github.com/XxKARLxX/oh-StarTrek/releases/download/v2.7.0/oh-StarTrek_v2.7.0.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "oh-StarTrek",
+
         "description": "以星际迷航为灵感的虎鲸笔记主题，拥有动态星空画布、任务完成时的跃迁动画，以及沉浸式无边框深色界面。支持Task及Task Planner动画（建议使用深色模式，浅色模式未优化）",
+
         "category": "主题"
+
       }
+
     }
+
   },
+
   {
+
     "author": "XxKARLxX",
+
     "id": "oh-StarTrek-LCARS",
+
     "name": "oh-StarTrek-LCARS",
+
     "description": "LCARS toolbox for Orca Note with PADD - Personal Access Display Device for quick settings access.",
+
     "category": "Productivity",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAADcAAAA3CAYAAACo29JGAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAZd0lEQVRogc2aabAkV3Xnf/dmZu1Vb997f713S61uLY0sPAIMRjADOIywISAcMCjCAQPhYBmCYRkz4zAT4DCe+TCYwUuMwcgMYpElBpAsISGERAu11N1Sr6+Xt+9bvapcKjPvvfMhs+q9193y57kRVVmVy8179v855wrS0dHRcQ/Atp3D7xzee/BDXb193eW2diEtGwApRXqUydGyEFJiSYmUEuHYWJaN49hYjoN0HKRtY2ccY9mOsSwrFkKqOIoAUCqWKoocHUfoMCKOYhFFkVAqRsUKo2KMNmit0cZgtAZjiI0GwBgwSlFfq7IwN70yOnLhwUvnzn7Z87zpJk1iI3G//Ttve3Dbzt3bPM9jfm6GuZkZgiDAAEaAEALSj7QToq1MFgC7WE7+53JYuTyyUMTOF7ALBWQ2j5XPJYvSBhOFqEYD5bsoz0uOvo8KAlTYSIj33OQYhslzKl4nKl14Lpelt3+Ant5+SqUC06PXFh7+3j/2toirVCp3ArztXe95rNLZ0zE9Mc5vTpzAVZrOXcMIy8ZAQhQGhEw+0kpmyCbEiUIBmclCNovI5pD5PCKXQ+byyFwWkcmClJh08abRQPsBOvDRQXKk0UC79eS67yXzp8ShVXrU6dINKMXKtavkJdx513GGtmzFra24P3n0h79XXVp6QlQqlTvv/jdv/PbWnfv2Xb50gRO/OUnvgUM0fI+VqUmcbIZcpYKQgqBaAyeVgBAgE0KFtEAKgrpLJpulu68XYzvYuTxGCIIootjWxtLiEuVyiYxlgdbUVqvkHJtGbQ2tFGuLy+SLHQgEaIVRGoxuESQw4M3RU9JU3ZjVwNC2fQe5chtzZ05z+7Hb2H/oMFNjV6d/9sj3j9gdXT33btu1b9/c3BwvvHCSwaPHmLlwnqFD+3j9R/6I7sP7aOrDuYd/hq70IQtFrh/K83j1we9w5PCtbNu+nbrrUiiX6Onrw63XyRdLPPaTn7Ktt4uurk76+vppeD6z01MMDA4xOnKZXz//Im9+/+fJlbo2WswmyckXvszn3ppcvjDp8jc/m+DJcxMMHj3KS6fOUGlrY2jHrsHhfQc+I3ftPfBAI4x4+cUX6D54mJlLF7n1Hb/Lm/7003Tdsq81t7nueP0wIrlSKZcod7Tjrq0xOz5OuVikWCoh4oipy5doVNdYmpqhmMuztryC1Ib+wUGujVxERyHitV6wmZUA7N9S5K8e2M/H3jrI7Pnz9Ozbx6mTJ4kaIVt37vqgXa607V5dmleLqzWrqydm8MBujnzg3WijIdLoMEJHEWhD7Pkoq54QaNYJFcYQ+x6WkBRKJSavjdLwAwAunD5DJpulEYYoLZBaE/k+oyOXKJTK1KqrvHryJcrlCtPTi4ReFSGt1MRF+g6DAIzREMYsuYZiRlPO2Agh+Oh9Wzg/WedkrUE1iFhZWaazs6dbfODD/8EdHRstXFmuUp2b5e1/+h/pPLQXozUTvzzByQd/QG1uEY1JVN+yE4fSNPAmiUKitSGXL6BUlCiVSZVLSoy009sNJk6cSiaXByGJohCjNVEYYUk7ec6yUo1I1TNOQoiMXGwUfe1Z/vi+bfzBPX0AnJ10+YOvnaN9+062FfPs3rsXGyGE7/s4xRKWY9OdquLSlXGe/qtvEDcSb6WFQGRy7Ni3j3yxyLULF/BXVzFpHCz3dLFl1y6cbAaAyaujrM7PI22bni2D9A4MAFCv1Zi6NkYUBPTu2EGpox0hJEZrlubnmR0dQ8cR5Y52hnbtwnGS+UcvXKS2MI/WmhjB+HLI5x+8zLa+PMd3V9i/pUh/CaJMBtfzkFJiJww2GKDY3dnS6vETL7UIAxCZHJlCkU/+ly9w4JbDfOz9H+LCyZMAFLs6+dxX/5x73/xGEGCM4dWXz/DFT/0n+gYH+PLXvkJXbzcIiMKIb33zf/Pdb/0Tf/KfP8tddx9vvaO6ssqXPvMFzp55hS/9xZc5/vq7EUJgMLz4qxN88eOfpD49scn6njq9xF27y0hgoDPLeCppbQxSKeWlThZp2a0gHdW9zTYchQjbRkgrYYVtI6RAAF0DA9xy9AjLS8v8+AePMjk+yfD+PWzbvZvbjx+np6+X0y+d4V9++gRaa47/1nHyxSJCSKIo5qnHn+LFX79Iub3C7a87zsD2HRy45RALc4s88sNHmJ+dZ2jbVgqldS9tjMEYQ72hMKllWOnahZQYrY0NIIRMg/T6MNf5RbHxumn+Fpsem52e4+v/46/56J98hOG9w6wuLqd3wS+efIaXTr7MnXfdgWVZCCuBcWGjwXe/8z2279zOsTuPASBtCyEE46NjfP2/f4OXf/MSY1evsby0zI1jfQHrYCMhX0ZRoyAt2brHGFJOXE8sSbBOH5YpQ4SUSNvBsW0koMIGP/jHB/nUhz/K6PnzYAy6CZlEygwhkNJK3mGakycMlVImQTxdaLFcwgjBxz71cQa3DIGTASeTzpXMJ9P7TUqsZVtoo2mi4pZo/9Uh1kk2G0Qm2Bz/Rk69AkojC/mWBvT2d/O2d76VYqnUWjiAkILtw9v5rde/DiGbi0zc7NbtW/jzv/iv7Nm/B6M1ViZz02U1sWZrTsvCGIOtjUFms4hGjMGg1WYXL9MHTIoptQGNTilNJmlOqtGosIFwHIxqgJRIaYMwvOd978ayrFRiaeQSAtu2+fRnP0kmm2Hs6iinXzqFiSKMgd7+XvKFPFEUYachSDYBNE3HkTiPliHZMmW2RraEaVn4K3UuP/wLLj/8NKtXpm7KoyYSWTe7jeorEtUFit1d5MqV1vmFuUX++Yc/pl6rp1nG+nNBEGCM5sc/+jG//tWvgcRzPvboY3z2E5/n4rlLrwmNrswFPHSiykMnqsytRkkMTmUjlTYIywZhkc93cXD4HRwcfiedbbtoetH1xWxQRSERlpWgCdlUMYmVzXPXm97AF//yv7Hv8OHELoGHvvtDfvTDRwnDJBgjEx2P4pjvfPu7eK7PPffeQ7FYYHFuga/+2Vd56J8e4tL5S+gWcBaYTC75iITBwzu2cf/v3cd73vU2+nu7QVrY+QJaaxIynTRtkRaZQhmnUELaN9Fv0frCyWXJVNrItFUQltNibLZY5O2//05uP34HdjazLuGNrGkZLgkgP3uBkYsj7Nm/l70HD5AtlnjfB9/HAx99gGwxl+aRN5dcLmPTVsrSVs5iO3YL2WijsTUGmctCrBH4LQ4189KW2gkgjhEYcrkcH/7Ih6mt1VhdWeXxnzyBUoq+gT4+/blPsGffHozRxFq38kCReuD1da7rWeg3eOLxn3Po1kO8+W1v4eEfPMKBQwcA+MznP8WOXduJ45hYRZg4zQ5a/DG0lEoAtoVVyGMMSGPAyuXXVWUDUzcOk6qGW6vjeR57D+zj2F13cPjILaytrnLi2ecAuO3YEfK5HC+/eIqJa2OEQYNqdY0wDDGxolarUa+7mFjjuS5razVUI+SFZ08weuUaBw7uI44iTr14CoAjt90KwHNP/5KlmdkbJBdrgxdEeEGENgIsG5nLJS7v3773jzy3vSd/dXEZPTrH/R//GgC/+tFf89LPH1p3r6mabj18iGJ7eysWhY2AidFxMtksg1u34jgZlDbMzc5Rr9Xp7O6iq6eLhbkFfD9gaMsgURwzPTVNf38fuWyGybEJojBkaOsQmazN5Pgk0rLoHxxolRdmxsZxF5dQYapdJpHgrh07OXrbEQB++esXsA8eZri7nTa/pm0D2PkCsLzuaYDXCnwT5y8hbAuTQi+EwAhB3Ai4cq6OSDP1pu4vLy6zvLScqDqC0cujyXVHMjs7h/JDDAbLEoxfvoyKY6RMij8j83NJFqE1Qumbrof2YeTB9wEC8eokOA5WvoDx69hGCOx8HlEoglza/KAQ6+ppmsgEUIq+/iE6entTr5cWjaRMSw9Wq8ZiNniR6vIqbq2OlQZZDGBnMaSlhFweHSZ5oFFRck4b3HqNuJmJi9Rh6PUqmCZFNZaNcBysQgGzIrCNFFjFQvJ+uUFyr+WegO7+fu687+0EUUjTOo2QFDs6iMOIhu+n5xIrFyKBRHucDNOXL5MpFFrTt8zcJKU7gQFtkHFa9TKG5fklzpx4/jXX0xQEALaDXShgpMBGSKx8HoqlhLhUVE14KaWT/E8JNwaybW2sVquMnjnFLcduIbs6yitXF9j12/cxc/UqhbYi2XIxlYBmaWaB0G8wtHcvywtzDO/fRb0R0b51KF2TRqQoH6Ww4gblsI6aGWV8dAKrfS9WU2I3qUMIkyAShATbxsoX0FJiaymNyKV2ckNmIG6QXxPNR1FE/5YtdOw/QHW6zNDK89Sra3j1Ndr721vxaXlqjkI5T31llcDzqdgh7+0b45u/XObs1UmylsELQto62il3dWHimIVr16gtzNA/1M/0vGJr+78uNNNElwKwbWQhT2xJZQvLCkQuW2gSqFWYBtcmflwHuJDYkI4UKoqZHp/APnsZgKllzUBfSBw0WJiYJ7Pq4/ir3NaRFFdf0HUiPyCI4Gy9HU+79JRs3nHQ4dvPVNFxBdEIiaI4LVfkKGUFyogEbaRF4Cb2FRvUWasQgUzOWTZWNocRUtlImVqqxF1b4eWnHgFgbuLKDZIENsvSwNLVayAE2qzbq1NfIhQQYvFqtYgQsBqF9KTXx4pHcVkGt8aVqQxhpOhpb6N7cJA4DFmemky0Q9s0Ah/VAvM3DndtiqkrT4IU+P4y5aYRCyltg0FojVEKp1Cm/+A9ACzMXIOxs0k2wLo6CiGJlcI4WXYduwNbJ8UeuWc4oVdpOoeHsUolJq5OsCISjQiVII4jgjhPo1aC2EJV2nl6rE6Ag+95+K7L6twskyOX6C7ZFAoNgnoNpRQqLRA1Q5RJbbBrzwCH3v9GhBBMTZ1PikvaYDC2bTZw5UYLk1w/Npqzt1YFregXKzTsMvXSAPmOLqYm5xGZFRp1F2QAGIqVCraTJWr4rMyNIzB0dnchrAwsLxMHAX5tDct22Hv0GN7KEot2hvbepKr2WkNsQFVC0KrKGaWwTaxQQQMaPhiDZTstCRlDkjCRcCPlACqK8et1nGwWmckxrbKAxPID9hxJ0IKdzWCUIqjXMFoThhG+51NoK1H3xih0lPEamrZyGSdfQAC+EthGQCaPdgq4MbT1D7FWrbVMpJkqiWacA2TGSYjUBuKYOPAxUYwdhxFRMy7p61CA0IC1+VTKqCgIUJ6PZafB2hiy2Qy1hYWWdBtejWJHkXp1rbWQQrlMJi8otHVSW/FxMjkKBNhOwtQ4tCgC2Z5uBBJjDHGxQH1xDq+2dnPpbXAuJoqJPBcTx9g6johdF8KYREWbgS4ppjT7cqYJx4RI8J7vkiuXkZaNEKBUYrdudRUEWFmLhldjcfIq05fHqHR1cPDuOzl76jfUllfYemA3/Tt2o0OPNn8Wz8vgDAwz+soJQs9FWhZBENDekcSBLTt3cvHUKUgxpWmZkFgvM2iFiUIi10VHEbYOI2K3DmGICn3qi1MYIAzqN8WXGduid8sWqouL1JYWyRcSdJMtlcgWy5S2b9l0f215gcHd23nHA/8e1w/Yd/w4T37rQaJGSG1pgYyOaSsVGDJrnDp3hko+R3t/H70DA/ziiSe493fezHf//m/p37HzRs3aOJprjWMit46OIqRRith1MW6diprl3uAfeEPwD2xR5zBGoVWEVhFCm+QjJCvzc0xdHmH68gi7hvfQWS5TX1hAxTH5coHubf1ki1niKEYg6N25l6sj1zjxkycZv3SV3uHdSVaNZM2LmWtkuVa10cLC91x+/4MfZOvuYXy3xsrSInEcY+I4AdFGY4xG6hipk/yy2bcwSmHiiNj10HGM1CpCe0kBtjOnefcxm3ffJtndKxDcKDmzwXNt27mdfbcdob23H5UmkQtTC0xfm2FpboUwCAncgPHzF6nXPKQl8bwGY2cvEDVC7HyRtsEt1Gs13EyFUt8gY1evcWHkMs/94hlqtTVWl5Y3FK1eS3LNYggQRcSei45jbBNrlO9jfC/pohidIhmBFAKd6njzBcYopBDc/aY3ceCuu3n8+w8x8sop2nr6KQUBBCGNIAXUxqBVzOrULGPFEj07dzBx9hxL42N0DvTS8H1ynT10VZJCkjc7jVIKz3XxfQ9jDEHog1GotCcumq6+2RtXChUECQKPQ4hCtCcQSmFrrSFtN220sdfsw6WS8+suY5dGGHnl1Cbim6MxNYkKfUqdnXh1l5WpMbzVJQLXJVcuUerqJHSrNJbmk+fjGL9a3Syd1nrScGT0DesS49fI/+z7SShYmIVsGyrQSK2xjTFEtSrGyiXN+Na8JtHbFKFokWTESsUgLWZnZpidmaHU2Y0A8pUKUaNBPoqpTU1QKuTBcRAW7Dh4aMN6Ez+nVIy7WsWUA8pdnYSex5rvks3lGB25hO/7dFdydJoVilk79dYGdLyJuKM7Ovn8u25BCDjz/GmuxIowcLFsgW20yiDtxGCv58pNJKfDkLb2ToqdXevhgbRTpDUyDCjmk5pM5+AghwZ6qKRqJzAs11cBcLxVfv6b8yxNTXLhxPNorejsH0zKfbkcsWXT15bhdf0uJ53Ntr5xbAAoCZ5q7XpIJCetKKgZmS+Pr2g+/dMEw50djdMOajqpSs5nK22U+wYwOmlW+LUlit1tYFtJpVdrkEVCv4GIQrq7OqlFDUysyGYy5ErJlo7OSp5iYZRD7T4De3bg+jHPTmq8Yol8by9trkeXGmdnb5HOos2qVpgNUtvI2KSFkfQdTKxQOsKQ9ufSu4kLbcwfuQ8D+AtPwtWFG8RntCb2NPvvfhcA01eeYf977kY1C7Ox4vT/eQy/7tIIGzx3+gz1vl7CtTUKtQbdQ1uRQjAyNUYYxowwxHTURRj7wIXW+5rI58qsi2XJ1hqvH2LjuSRrRccRxs5g+42oDGAcJ5Gx7bRavWLDhC2IozXR8jW6558AYOTyeS4+aiNT+KSjiMXLozjFEoHrk4kjRG4FU62yuFyjkdpw3nNRSqEzGlkwKEvgawtjNI21GpEfEIYhiKQXEDcr1U1atGn9lWnuaUzqdOKkZ7cuuY0PXv9742mjGO7N8Nl39KAxfDXoZarr9qQkb0CriPn8GI24DllwbElHZxnPFsxncjgDPYBBTDQwWlPM52lrbyP0XFYQNNyA+vQ01ZlpcEOUhpqnIJcSdJMcc9OCmwdtsHW6Fwunufh1tG2MWE9YU+ijwgbnpn3u/7PHAc38WozK/B3N9EhKgbA0vlvF0Qq7eyvBzAomCikFIXJsAmMMGWkRKk19bJL58QmM1jjFCuXuPmYuXULHIS4d/N3zHhS6CdZqCa7dsIEI4MrEIg89fgowzC2uQXsHKo4wOrMuuRsyOcfmZiMOAq6ePc3V1oNpUSmtXzZn0koxKyVjr76U3mM2ZfYqjonCcFM+BrSKsImEJKARGOIw5GZjoNDgSNssRkDBjqiROBsD2JmMU02Jawuq1VayV9m+DZ59viXJlskZTeit98tbixPNOmVylFKilMJN93qJVvUstZXmvE2b3lCHTMm87nh94py8942H2+koWmQcyUotQudUEh60QgqjZgAiz0UgcKeSvlxp+1YG7zh6U279/zLuv7ubew8moeXiTIPZWsKgrOMQRwG2MOZlMPujxQU6tmxn6tnn2fOH70ZKybb73kL73j3Up2cwWuNOT1Hs7kFkMjQLas3ixMZWFSKJN7pWY8uRg+lJs+E7Gd7EJMcrEd2VpM5ycmSFWbkHO1egBdtbiWiKUCaf5Q17DIe2Frlnfxk7Fej/+tkEle3D+HPTOAPdrFXXtC3QP4hj/d6utpLwpaQ2M8f0088w9MZ7AajsGaayZxgwLLz4Ep0H9iflai02vJSkySjX4ZtuNFDTU9z2gftbhBshMMIk7SVg+VfP8cEhl/3bu8DAN//vJU5l/x359madbH20HN3zo/zxW+JNQfwbj8/wL+fqdO/dTrFcIAob+F7thHzZqz0qBK/m81mi+WkG9u1j9vQZLn3v+3jTM6BU2oxIUH6r4CsAYZKFJwFx3ZM15SmbXte0drs2d0sYkxLbkmczn04rzxtyt1a2YnTCHAGWZTEyE/CJvx/hfz45T98tR/GnxikWcqgo1HPzs18RAIdvu+MNws48BTC3uEqmb4Ag9KmOTWDlMmRKRRCSqF7HKeTXN5LCOrhrekopW79NHFPq6958vTm0Jlqr0mdF5GyJMIa5FR9fdKSbAlIu6oSJTR7o2iSDFcNSrcGSa6hs20WuVMGfGqe/q4244eu1tdWvTE2MfqH1tkO33v6Aga9L23GiRsC8G5Hv6W21opoLE0KkapZ6vzRkiHQPpnGcZK9Ixkls03GSj2WlHtUk4DaOIYySnbBRBFGICUOIkmsiWt8ha4xJeglNHkELoXjzc3TkMxRzDnEYrISN8FtXRs59Gog3uYFDt97+4VipvwFaPfFGFKdEJRJplrWFZSc7fRwHmclg5bLIbA4rX8AqFJDFInaphFUqYhXy2K1yfRJqlOcTuy6qXkfVXbSb7ncOgnSvc5Bs2UizFZXCL63ilnk4jkXGtqj7IVmpVsIo/NKVi+e+ntITb46gwLZt2zpKHT0fMkr/IUIcApFvaZRpNrTFuok0m+cyUUlpWWA5Sa8sk0hNOHa6YyKtpCmVbDGMYnQcQRiDipLzWrXsu9nWaqrkRo8rkveHRqsLAvnPterCNycmJqY30vL/AERmFU92kNOtAAAAAElFTkSuQmCC",
+
     "version": "1.1.2",
+
     "updated": "2026-05-18T07:36:02Z",
+
     "home": "https://github.com/XxKARLxX/oh-StarTrek-LCARS",
+
     "zip": "https://github.com/XxKARLxX/oh-StarTrek-LCARS/releases/download/v1.1.2/oh-StarTrek-LCARS_v1.1.2.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "oh-StarTrek-LCARS",
+
         "description": "星际迷航风格 LCARS 工具箱，首个工具 PADD 可将设置开关钉选到侧边栏快速切换。",
+
         "category": "效率工具"
+
       }
+
     }
+
   },
+
   {
+
     "author": "hqweay",
+
     "id": "orca-hqweay-go",
+
     "name": "Dino Craft",
+
     "description": "Dino Craft - some tools",
+
     "category": "Productivity",
+
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAAAXNSR0IArs4c6QAAEPhJREFUeF7tXQtwFdUZPqFFE4LhZnTCQ1OCQmywQCwaIgghYxWxgsFQZphRQLTOODJKtFPUkSYxjo+ZlqDjY6ooj6rpICptKASDTUKIQCoSDQ+NkSTGBMw05CoJpuKQ5tvcc917s49zdvfs3b3ZnWHCvXf3PP7/O99//v/8e04MicJr5b3zVn9U25CPrn1a1+S77vrJpKf7e/8vUkZ/gu92bD8wNwq7bahLMYaecuhDVPHxI+N8eWtyCRQffq17ZhspfvYdcmtOZpUHBEKiBgC35mRWdv73u6xwxQ+LJeR872DEAghffN425EEQFQCgyt9aupaLmzwQRAEDGFU+RcpQB0E0MEBfa1dJcOSrUb4WNSxZUETSJifnvf7K7vVcFBIFN7saABj9k668NOuhRxabUsX+fcfIk2vf8H9a15RoqiAXPuxqABBCQka/GfkPVRZwLQCsGv0UNEOVBVwNgGV335il5OsbZYLkxKV4lEkmrV0lCCbl7955yFdTVe/Dg5V7pDgTaTpxqjnQhkJ8bbQ9djzH1Fk7GmKgDsvon9bNYgao4tc9s20uAkqIO+ACECkYwSZfNp7c/GjehvGyfjkSDK4FwHXXT+7j9fv1QAaX8NuublVvoLWrpEKueIbJZ2E/qxT0s4DEFoSQqv424LNjLlcCACHf48dai0UAQCk6GBj1FWCIzFlphEHxROaOUhBA6VT5jgGBawEwKnFkMYsieIYaqHvLa+WDwsN5a3L7KN0brDM7OXEpnQs4CgSuBYBdDLDhzT8cfu3lnekm2aYyOXFptgyMff3mAJ8jPkH0ACDTSnhYuD/CWLBkQVG+2soiD7tA4U5kAVcCIDDrFjoJhN1fsqCogtXmM4BBiQUiLv+IN4BBcIq3TE2f0PV40R1SsodVFyZ5+/cdk2TydPE9m/75zofLTVJ/SNOSE5fK5e2IuYBrAYBIIA0E7dpzWBL03qr6oMA/rW0k586fD36enpk6CCdzsqZI383/zdXS399mPxZcD4CbaRH1y+uVmwHqGsrnBlZhmbkcVwFg9uIZq9Gz5vrW/GExMRe2fNYWN/HqFKmzE9MDfwOftSTQeJgG6ghprGsm9PP4tEt/TBwzqmbURfG//OF0z2grR3+gPXIA4CtMBiOqg4hWrgdTKPxM55mcznb/tNbP231QNhSNv6nXpShm+uiVqfd72esDE3MKjDtWzZc+P120TO9Rlt/lMQEPAEoSg9IxwvHbhSMu8N1810D+Jh3pLFK28h6wA/6VbawkUzMmkakZE82AwQOAmnLSsydXYqRTpUdK4Xqmg4LBIDOEm4CKQDzASsxylRVRE0BHO+gdI12ieAYbztVDQTfLmQFgYDQRQQDcsvDaFxIS4u8+dqSlF1nM8maeaj/dvPdQ8V2yuIGgXkRoAkIV7+TRziNxzBtgIvSAADdwSvqETfV1TcvpKqJSaBkhaYSeF+bOxIriCp628N5rKwNEm+LDha0FhN07D9Uhb8CXODKFZT0BIEBcorWrJNxs8OpY837bAAAb3+0/m0Wp3tJeOKywcCAgxHyg5riUO8ATuMJz/q7u5o2v7J4gqovCAYBRX73tYDEUf/PKofVGFoDw2YdfkGt/fQVZ99J9hnTIk6VkpAKhAEi+clxXtNh5I8LFM6zzA7Xy5eFpo23Qek4IAFhGvZH8fRECsKJMlr4ACJfEx7F6C8FmuQ4AQ8nW84JHjQ20AOQqAIDyr5qZ6htqtp4HCDSQhGVmltiBfIGKpx7Wey0xAdS985TPKvaBuYGeSYAruObBV5ubTpxyrhdA7f2q51c4LorHYpvZVWb9nQBB+9E28q/dTygWzpKmbrZVphjAyco3Kxi7ngcIWupbyfvlTw6qcs70PKGjHxUaBoCnfOsgogQCBIGSxiQ6MxTsKd865dOS5ObADttP6+VmAE/51is/HATxFwxHbqItaePcAPBcPXEAoJHDztbOb/+zZ+CFU9EXFwAQ5BmTkpTl+fli1fLCA5vI/3p+2Nza0C50KZhrEugpX6zSw0tfPbuAzF48I69620Gh29YwMQAN78LX9y57JICIIZgA+xl+1fzNtPBap2ek+mMIea7w2RV1ZjKHmACA9OX11Y55oVWIBpwYNIJn0PRxMyl68s6QPAJ4CbjwF3kG2AX1mozUQiObXOkCwKN+a/HGCzSwwB8fWxJ8eUWpNTSFDEDg3ehKEwBmlc/bWWtFHR2lUVMg3wpPrWc082hr6VrmNDI9BugTGeNH59ySBSwXut3t1lszkLcNbLCrtJY5jUwVAGZHv9b4o0ui9JUsgEAtV9BJLELX82nf7ExzYzEFtF08u59qMYCwiR9cHKVLJNuYNQhQ/vsllYNeR7MLBBgsH2ypVlw0Cu+baQCIHP3ho0jeeDCBU11NNdCi/XYBl4cFWBNJ1BhAc/SboWUtQUKYTnQ3tUCLNtsFXB4WMAwAkaOfzmi16Niu0cRjEvQAYCdwWViAZ9dTJQYQZvtZBGmXTeUBAIQu31MgkvMXFhbgySQKAYDI0Q+heQDggZ36vTCj2LxC6S0jntGPGgYB4PpFGVmifHMPANYAQM0M8Cp/EAAmXp0iBX5EXW6dA7CYADsnr0pmgB6Gxbv/YJABtOjfzKw/PIIGYWpddgqSFeh6wLXLC5C3V84CUP72t2sMJZAGAYBMn4c33Cs8C0VrNDlxAkiF7rR2A5R1pYfJvvJPTB2BJ58DCJv9s7KAE0c/bbva/CUSox9tAgBKXy7/seV423BWJlO6TwKA6Nl/eMVKlBpJ/5/VxIWDIFLKD2MlvQU9TXxEBADyUeWmfYFEtZsVgOGahFkae8VoU2ljFD220L8ZqvKeHSwBMOm763aebm/uuNiofDwAGJCc0RFroCrNR6R5wEvlpOWzNsMTwRi86HHyy2+KRfr/VnfcK+8nCSAqiGwhuIIf7P6YOzcwxu4JoKc8ayWAeUDFv5+WCpUFg5gnhh4ArNWH7aWFh4V5kkHQ2BgEgG67/yZpI2bvcp8E4JrefktGSNYwDwgcCwCnTLScDgkAYHxiAnl8rXToZdAUKJ1+ptQXCQB2hICdLki3tk9tqxmejCBDMQCtERp/QWyIPOOHx5Gec99L3+G5M9/1ulXeTO3W6j8K6PnBuv7DFfQ3fDNowynhAJBLAh2GkuOHx5LwzqtJDELoOTcgiI6eLibBOvWmSPYfANj7Rk3IPkM8eQFwFwwxAJSBjieNSGRWupYCO3r8rgOCE/qvBADelDBDAEiKTyRJ8dauHrsJBE7pfzgAeEa/5AYaZYBfJYnZuq7Jf9KUjbTLe3BK/8PnADyj3zAAQH0TfGOFmGQ3sICT+k8BsHDeNdL5Aivvnad6+rmiG2iUAQAA1gkfD1KOdDTx3B6xe53SfwDgyJ6jZOSwn+HQa7xzx3UecYyZRFAr7SC8AtC/qEuEaXBC/xEHMLOplCWBIAiCxwWkSqb+cMfZLlN2XxRoWMuNZP8BgFPNHVV1FccMncZhCQCUYgL0OwAjqPCA30+DQt8P6xVy+COr4kTcR2MCLP23IiBkCQBYFoNEUCiPAtBRnObp5S2ESg1yOVrTYHhLOccuBoWDA4kPTs4a5gGzlfcCAN1fdxFffFwVyt2x/QCXKZDyAUS+DmZFZ9FJXFobVOpt24Iy3JiAqic/5AM89cTALmI8y8C0XFcAAJ3Uon4W5bLcoydsJ/4uzwhC+3hBIOUExl8UV+zk7V+1AEBz9fXeK0AZ0XhmIc0JlIOTJxroiqRQNeXRF0ygWL0JYjTMIZQm4n/N+9ugfYOwHlBWWssUEZSSB80Eg+ygRbqrmNwMUOXTkQ+QTExPUZwnsMwh7OiH1XUorQTSOnjyAfCMoRVBqzukVR6lejrapUlh4MRx+hwFAZ0wUuDgczS6j2rZQGCALa+VIzSs6xFIDOCmtDC9yRyULv2rax7wHMJAYidoRdelBgBMBL/t6mY3AV5msFhViQqiyV1A2gNuLwAPGvUERHVMrDqip/RwD4BX+ZCEZAK818PcBwp5HgBsPo6Zx/kBvFvG275BhPtE7cwWw/53NHWQH/3GzwoIMgCdCLIsCjlTHEOvVbD/qWmXbd/51r7neJNA5NIKMoDRecDQE70zegz7n7cm17oTQ7x5gDMUi1boTa7D3T96YsjFlyQw+f6KDOCZAecAQK8lSu8D4hm6RwDPsTEh75GDBabNSSv23hTWU0Fkf1daADIVBwg8XDBp+oTMvvN986IxbBpZlQ2unUYseVdh1aJ/8hoCG0UwbRIR4gaikMtSx/bmrJoX67GAWMgYBYDW6DfCAhQAWDTIxz6z/SxQ5rGAvvL1Jmr6JRDpYEgetlV7Ezi8Lu7FoP4C6CE+0t/ktHHnbrvvpp97LMCiRuP38AKAhf7RGp73A4PbxMm3jr/zT7ll+0sPeXMB47plepIXACynhdCKefIBgvRPH15fXVDxwgOb5kbzUiqThiy+qXZXHcmYnx4slTdLCSbgQMl+8t5O7WN8eZeDQ+gfrVtfXdCnlIVjsTwcV5wVdl2rUwDA6ZP+YNYSLwOgbKSA3XxDOnnokcWqVbGOfhQgvR4up//i6oK5MYRU4EetNCvHac8lDZKnpxkBALr5+sNvkhuypyqCAPa/aO0bm+vrmphO/gAAwABZVH7xo0b4xl6eJPHUpZPGkKqtB2w7F88lOjTdTPqWEwri8QLkFdMUOawHUDYwEwkMyR2bvXjGT4Yqpi/rZGNHjtGGmpaWV4CmBCgQMmelkbM9vYNOD5+SPmHTNRmpWYdqG6TtXJYuv+Efj+ZtwLEt0ts2TNEibztZ56Nww5q3eo982PBsgNGxeXTlju0HssAQeGsI/+iiEf7SjSSYAIDuI2/wqpmpPt7QJavorJyAWVkWa/udcB9lg5TLx7Qs+t2s8WoTRQAAL4+0dpVkMwPADhA4QYhubwO8tx0vlpNFOZmangLmC4E0Mr4ui2YCvtZ4d6tJAHsHjvcl6LqLXAxAK/NA4A7gqeUN0NbDDBgCAAoQNTG0w37bUYdTIAIQtB9tC9lJlLYNASPDAKAg6PafzfJCxk5Rt3I7lECAieCaB19FKrm5C0xQV3FMAoEoD8FcC72nIQHqIdBDp0H/C3NnbjYNACpeDwjOBxoFQf5Ty8iWDe9LR81aBgBqEjw2cDYQZId25mHdz1IAKLEBvvNMg7NAIQNBjBAAeEAQp3CrPBiYg+p3a+uEAkAOBPyfmgePFcQBhKfkv9zzijk3kKcyORg62/3TWj9v98FzGKpgsGokG9EBfSYiAJA3GJ4DZQZpD7/0gaPronE/PzOKEvEs3WLWFhPA0gG8lXSm80wO7qUMIQcFBYb8L0u53j2hEqDvI5RtHEgHcAwAVBRV0A8MPwVGW+Op8bEjYqXEBpgQtbR1yiRmlU/3GVIrRzSNQ1lWX8lXjvOjzJQpyYXV2w6KcQN5G01H//InlhTkzS6gBx4MSlZVKhfPqtVHgSP/vbPNL0k1ZWpyHVc7Y/qyek6fnXLjstmNrz7yd3LVrNQyrucDN1dvO0jr5TrYwUhdLM9EnAHoohIaixF3//MrsgMgQGJqNksnRN+DNtI1D4zK47WNjS1Hv/69mY0ZRLeZtfyIA2DV8yv6KJVDuB1fdW7e+udSyn3aCfCsvTR535zcGU23r54fPFy55r2Put9et2OBBwCTgsXj8j0KMTOdt3Ju4cM3FuSf7zW+VG1Bs0KKuOeppYdjR16YDqCijSfqv/I3fHRikQcACySN9xDeW79r44iEuJSEiy/C6EfGKgIEjhj9tIvUDIy7fHTz3ncOgqEKowEA/wfh9PpkMENSLAAAAABJRU5ErkJggg==",
+
     "version": "3.3.0",
+
     "updated": "2026-06-29T15:25:10.963Z",
+
     "home": "https://github.com/hqweay/orca-hqweay-go",
+
     "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v3.3.0/package.zip",
+
     "translations": {
+
       "zh": {
+
         "name": "恐龙工具箱",
+
         "description": "一些快捷工具合集",
+
         "category": "效率工具"
+
       }
+
     }
+
   }
+
 ]


### PR DESCRIPTION
## Update orca-import-export to v3.0.0

### Changes
- **version**: 2.4.7 → 3.0.0
- **icon_svg**: Updated to new C2 monoline glyph design (blue export arrow + purple import arrow on dark navy background, 80x80)
- **zip**: Updated to v3.0.0 release
- **description**: Added Anki card-making, resume import, cloze syntax support

### Release
- [v3.0.0](https://github.com/Peng52050/orca-import-export/releases/tag/v3.0.0)
- [zip download](https://github.com/Peng52050/orca-import-export/releases/download/v3.0.0/orca-import-export_v3.0.0.zip)

### Verification
- [x] `package.json` contains `version` field
- [x] `dist/` folder included in zip
- [x] `LICENSE` included in zip
- [x] `icon.png` included in zip (80x80, ≤80x80)
- [x] `icon.svg` dimensions ≤ 80x80
- [x] All links (home, zip) work correctly
- [x] Plugin is functional and documented
- [x] Alphabetical order maintained (author=Peng52050, id=orca-import-export)