### PR TITLE
feat: update Orca SRS to 1.0.9

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -215,10 +215,10 @@
     "description": "A spaced repetition and incremental reading plugin for Orca Note with FSRS scheduling, multiple card types, AI card generation, EPUB/web import, and reading workflows.",
     "category": "Productivity",
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAA40lEQVR4nO3awRHDMAhEUXfgY3pIBWnefeWYVGAvSLBI7Axn+b/Rzeg4X++l56AXCMAuEIBdIAC7oDrgc31XAvxzkSkHALsjJKMAd/oshh8wJX2c4QRMr3cbPICgep/BDAitdxhsgIR6q8EASKs3GVBAcj1ugACUetDQAECsRwy7A+j1jwYBKgPo3YhBAAEE2BVALwYN+96AAAIIsD6gjuGmUIDigAqG+7wGAK7hsa0HgGVAwtr8nU424EnNNjQJBmtMyy1lkMGX0XhTP4Ux/mm9VgFIoefrxRZ7BGCPAOxZHvADvnxNjjg5nvMAAAAASUVORK5CYII=",
-    "version": "1.0.8",
-    "updated": "2026-08-01T15:21:51Z",
+    "version": "1.0.9",
+    "updated": "2026-08-08T09:43:40Z",
     "home": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin",
-    "zip": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.8/orca-srs-1.0.8.zip",
+    "zip": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.9/orca-srs-1.0.9.zip",
     "translations": {
       "zh": {
         "name": "虎鲸标记",


### PR DESCRIPTION
## Orca SRS 1.0.9

更新 orca-srs 插件条目至 **1.0.9**：

- `version`: 1.0.8 → 1.0.9
- `zip`: 指向 `v1.0.9` release 的 `orca-srs-1.0.9.zip`
- `updated`: 2026-08-08

### 1.0.9 变更亮点
- 图片遮罩（Image Occlusion）编辑与复习
- Azure TTS：选区语音、批量 TTS、多语言 voice
- 卡片浏览器筛选/查询与批量操作；暂停卡片视图
- 复习服务设置面板与 UI 偏好（Pass-Fail / 下次复习时间）
- AI 跨块源选区与有界子树展开；前序连续区间摘录
- 章末小测生成偏好与学习闭环完善

> 关联发布：https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/tag/v1.0.9