### PR TITLE
Update Mcard plugin to v1.1.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -690,10 +690,10 @@
     "description": "A flomo-inspired card-style note-taking plugin for Orca Note, with tag management, parent-child card linking, and daily review.",
     "category": "Productivity",
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" width=\"64\" height=\"64\"><rect width=\"64\" height=\"64\" rx=\"14\" fill=\"#4A90D9\"/><rect x=\"12\" y=\"10\" width=\"40\" height=\"44\" rx=\"6\" fill=\"#fff\" opacity=\"0.95\"/><rect x=\"18\" y=\"18\" width=\"28\" height=\"3\" rx=\"1.5\" fill=\"#4A90D9\" opacity=\"0.7\"/><rect x=\"18\" y=\"26\" width=\"20\" height=\"2\" rx=\"1\" fill=\"#8AB4E0\" opacity=\"0.6\"/><rect x=\"18\" y=\"32\" width=\"24\" height=\"2\" rx=\"1\" fill=\"#8AB4E0\" opacity=\"0.6\"/><rect x=\"18\" y=\"38\" width=\"16\" height=\"2\" rx=\"1\" fill=\"#8AB4E0\" opacity=\"0.6\"/></svg>",
-    "version": "1.0.0",
-    "updated": "2026-06-23T10:00:00Z",
+    "version": "1.1.0",
+    "updated": "2026-08-11T12:55:05Z",
     "home": "https://github.com/leommjj/orca-plugin-mcard",
-    "zip": "https://github.com/leommjj/orca-plugin-mcard/releases/download/v1.0.0/orca-plugin-mcard-v1.0.0.zip",
+    "zip": "https://github.com/leommjj/orca-plugin-mcard/releases/download/v1.1.0/orca-plugin-mcard-v1.1.0.zip",
     "translations": {
       "zh": {
         "name": "Mcard",


### PR DESCRIPTION
Update the Mcard plugin entry in plugins.json to v1.1.0.

- version: 1.0.0 -> 1.1.0
- updated: refreshed timestamp
- zip: point to the v1.1.0 release asset

Changes in v1.1.0: plugin assets are now stored under `assets/plugins/<pluginName>/` so they are exempt from Orca's unused-asset cleanup; asset references stay flat (`![](./xxx.png)`) with display-layer resolution, and S3 sync keeps a flat layout.