### PR TITLE
Update hqweay plugins (orca-hqweay-go, lets-ai-toolbar, lets-embed-view) to v4.3.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -825,10 +825,10 @@
     "description": "Dino Craft - some tools",
     "category": "Productivity",
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAAAXNSR0IArs4c6QAAEPhJREFUeF7tXQtwFdUZPqFFE4LhZnTCQ1OCQmywQCwaIgghYxWxgsFQZphRQLTOODJKtFPUkSYxjo+ZlqDjY6ooj6rpICptKASDTUKIQCoSDQ+NkSTGBMw05CoJpuKQ5tvcc917s49zdvfs3b3ZnWHCvXf3PP7/O99//v/8e04MicJr5b3zVn9U25CPrn1a1+S77vrJpKf7e/8vUkZ/gu92bD8wNwq7bahLMYaecuhDVPHxI+N8eWtyCRQffq17ZhspfvYdcmtOZpUHBEKiBgC35mRWdv73u6xwxQ+LJeR872DEAghffN425EEQFQCgyt9aupaLmzwQRAEDGFU+RcpQB0E0MEBfa1dJcOSrUb4WNSxZUETSJifnvf7K7vVcFBIFN7saABj9k668NOuhRxabUsX+fcfIk2vf8H9a15RoqiAXPuxqABBCQka/GfkPVRZwLQCsGv0UNEOVBVwNgGV335il5OsbZYLkxKV4lEkmrV0lCCbl7955yFdTVe/Dg5V7pDgTaTpxqjnQhkJ8bbQ9djzH1Fk7GmKgDsvon9bNYgao4tc9s20uAkqIO+ACECkYwSZfNp7c/GjehvGyfjkSDK4FwHXXT+7j9fv1QAaX8NuublVvoLWrpEKueIbJZ2E/qxT0s4DEFoSQqv424LNjLlcCACHf48dai0UAQCk6GBj1FWCIzFlphEHxROaOUhBA6VT5jgGBawEwKnFkMYsieIYaqHvLa+WDwsN5a3L7KN0brDM7OXEpnQs4CgSuBYBdDLDhzT8cfu3lnekm2aYyOXFptgyMff3mAJ8jPkH0ACDTSnhYuD/CWLBkQVG+2soiD7tA4U5kAVcCIDDrFjoJhN1fsqCogtXmM4BBiQUiLv+IN4BBcIq3TE2f0PV40R1SsodVFyZ5+/cdk2TydPE9m/75zofLTVJ/SNOSE5fK5e2IuYBrAYBIIA0E7dpzWBL03qr6oMA/rW0k586fD36enpk6CCdzsqZI383/zdXS399mPxZcD4CbaRH1y+uVmwHqGsrnBlZhmbkcVwFg9uIZq9Gz5vrW/GExMRe2fNYWN/HqFKmzE9MDfwOftSTQeJgG6ghprGsm9PP4tEt/TBwzqmbURfG//OF0z2grR3+gPXIA4CtMBiOqg4hWrgdTKPxM55mcznb/tNbP231QNhSNv6nXpShm+uiVqfd72esDE3MKjDtWzZc+P120TO9Rlt/lMQEPAEoSg9IxwvHbhSMu8N1810D+Jh3pLFK28h6wA/6VbawkUzMmkakZE82AwQOAmnLSsydXYqRTpUdK4Xqmg4LBIDOEm4CKQDzASsxylRVRE0BHO+gdI12ieAYbztVDQTfLmQFgYDQRQQDcsvDaFxIS4u8+dqSlF1nM8maeaj/dvPdQ8V2yuIGgXkRoAkIV7+TRziNxzBtgIvSAADdwSvqETfV1TcvpKqJSaBkhaYSeF+bOxIriCp628N5rKwNEm+LDha0FhN07D9Uhb8CXODKFZT0BIEBcorWrJNxs8OpY837bAAAb3+0/m0Wp3tJeOKywcCAgxHyg5riUO8ATuMJz/q7u5o2v7J4gqovCAYBRX73tYDEUf/PKofVGFoDw2YdfkGt/fQVZ99J9hnTIk6VkpAKhAEi+clxXtNh5I8LFM6zzA7Xy5eFpo23Qek4IAFhGvZH8fRECsKJMlr4ACJfEx7F6C8FmuQ4AQ8nW84JHjQ20AOQqAIDyr5qZ6htqtp4HCDSQhGVmltiBfIGKpx7Wey0xAdS985TPKvaBuYGeSYAruObBV5ubTpxyrhdA7f2q51c4LorHYpvZVWb9nQBB+9E28q/dTygWzpKmbrZVphjAyco3Kxi7ngcIWupbyfvlTw6qcs70PKGjHxUaBoCnfOsgogQCBIGSxiQ6MxTsKd865dOS5ObADttP6+VmAE/51is/HATxFwxHbqItaePcAPBcPXEAoJHDztbOb/+zZ+CFU9EXFwAQ5BmTkpTl+fli1fLCA5vI/3p+2Nza0C50KZhrEugpX6zSw0tfPbuAzF48I69620Gh29YwMQAN78LX9y57JICIIZgA+xl+1fzNtPBap2ek+mMIea7w2RV1ZjKHmACA9OX11Y55oVWIBpwYNIJn0PRxMyl68s6QPAJ4CbjwF3kG2AX1mozUQiObXOkCwKN+a/HGCzSwwB8fWxJ8eUWpNTSFDEDg3ehKEwBmlc/bWWtFHR2lUVMg3wpPrWc082hr6VrmNDI9BugTGeNH59ySBSwXut3t1lszkLcNbLCrtJY5jUwVAGZHv9b4o0ui9JUsgEAtV9BJLELX82nf7ExzYzEFtF08u59qMYCwiR9cHKVLJNuYNQhQ/vsllYNeR7MLBBgsH2ypVlw0Cu+baQCIHP3ho0jeeDCBU11NNdCi/XYBl4cFWBNJ1BhAc/SboWUtQUKYTnQ3tUCLNtsFXB4WMAwAkaOfzmi16Niu0cRjEvQAYCdwWViAZ9dTJQYQZvtZBGmXTeUBAIQu31MgkvMXFhbgySQKAYDI0Q+heQDggZ36vTCj2LxC6S0jntGPGgYB4PpFGVmifHMPANYAQM0M8Cp/EAAmXp0iBX5EXW6dA7CYADsnr0pmgB6Gxbv/YJABtOjfzKw/PIIGYWpddgqSFeh6wLXLC5C3V84CUP72t2sMJZAGAYBMn4c33Cs8C0VrNDlxAkiF7rR2A5R1pYfJvvJPTB2BJ58DCJv9s7KAE0c/bbva/CUSox9tAgBKXy7/seV423BWJlO6TwKA6Nl/eMVKlBpJ/5/VxIWDIFLKD2MlvQU9TXxEBADyUeWmfYFEtZsVgOGahFkae8VoU2ljFD220L8ZqvKeHSwBMOm763aebm/uuNiofDwAGJCc0RFroCrNR6R5wEvlpOWzNsMTwRi86HHyy2+KRfr/VnfcK+8nCSAqiGwhuIIf7P6YOzcwxu4JoKc8ayWAeUDFv5+WCpUFg5gnhh4ArNWH7aWFh4V5kkHQ2BgEgG67/yZpI2bvcp8E4JrefktGSNYwDwgcCwCnTLScDgkAYHxiAnl8rXToZdAUKJ1+ptQXCQB2hICdLki3tk9tqxmejCBDMQCtERp/QWyIPOOHx5Gec99L3+G5M9/1ulXeTO3W6j8K6PnBuv7DFfQ3fDNowynhAJBLAh2GkuOHx5LwzqtJDELoOTcgiI6eLibBOvWmSPYfANj7Rk3IPkM8eQFwFwwxAJSBjieNSGRWupYCO3r8rgOCE/qvBADelDBDAEiKTyRJ8dauHrsJBE7pfzgAeEa/5AYaZYBfJYnZuq7Jf9KUjbTLe3BK/8PnADyj3zAAQH0TfGOFmGQ3sICT+k8BsHDeNdL5Aivvnad6+rmiG2iUAQAA1gkfD1KOdDTx3B6xe53SfwDgyJ6jZOSwn+HQa7xzx3UecYyZRFAr7SC8AtC/qEuEaXBC/xEHMLOplCWBIAiCxwWkSqb+cMfZLlN2XxRoWMuNZP8BgFPNHVV1FccMncZhCQCUYgL0OwAjqPCA30+DQt8P6xVy+COr4kTcR2MCLP23IiBkCQBYFoNEUCiPAtBRnObp5S2ESg1yOVrTYHhLOccuBoWDA4kPTs4a5gGzlfcCAN1fdxFffFwVyt2x/QCXKZDyAUS+DmZFZ9FJXFobVOpt24Iy3JiAqic/5AM89cTALmI8y8C0XFcAAJ3Uon4W5bLcoydsJ/4uzwhC+3hBIOUExl8UV+zk7V+1AEBz9fXeK0AZ0XhmIc0JlIOTJxroiqRQNeXRF0ygWL0JYjTMIZQm4n/N+9ugfYOwHlBWWssUEZSSB80Eg+ygRbqrmNwMUOXTkQ+QTExPUZwnsMwh7OiH1XUorQTSOnjyAfCMoRVBqzukVR6lejrapUlh4MRx+hwFAZ0wUuDgczS6j2rZQGCALa+VIzSs6xFIDOCmtDC9yRyULv2rax7wHMJAYidoRdelBgBMBL/t6mY3AV5msFhViQqiyV1A2gNuLwAPGvUERHVMrDqip/RwD4BX+ZCEZAK818PcBwp5HgBsPo6Zx/kBvFvG275BhPtE7cwWw/53NHWQH/3GzwoIMgCdCLIsCjlTHEOvVbD/qWmXbd/51r7neJNA5NIKMoDRecDQE70zegz7n7cm17oTQ7x5gDMUi1boTa7D3T96YsjFlyQw+f6KDOCZAecAQK8lSu8D4hm6RwDPsTEh75GDBabNSSv23hTWU0Fkf1daADIVBwg8XDBp+oTMvvN986IxbBpZlQ2unUYseVdh1aJ/8hoCG0UwbRIR4gaikMtSx/bmrJoX67GAWMgYBYDW6DfCAhQAWDTIxz6z/SxQ5rGAvvL1Jmr6JRDpYEgetlV7Ezi8Lu7FoP4C6CE+0t/ktHHnbrvvpp97LMCiRuP38AKAhf7RGp73A4PbxMm3jr/zT7ll+0sPeXMB47plepIXACynhdCKefIBgvRPH15fXVDxwgOb5kbzUiqThiy+qXZXHcmYnx4slTdLCSbgQMl+8t5O7WN8eZeDQ+gfrVtfXdCnlIVjsTwcV5wVdl2rUwDA6ZP+YNYSLwOgbKSA3XxDOnnokcWqVbGOfhQgvR4up//i6oK5MYRU4EetNCvHac8lDZKnpxkBALr5+sNvkhuypyqCAPa/aO0bm+vrmphO/gAAwABZVH7xo0b4xl6eJPHUpZPGkKqtB2w7F88lOjTdTPqWEwri8QLkFdMUOawHUDYwEwkMyR2bvXjGT4Yqpi/rZGNHjtGGmpaWV4CmBCgQMmelkbM9vYNOD5+SPmHTNRmpWYdqG6TtXJYuv+Efj+ZtwLEt0ts2TNEibztZ56Nww5q3eo982PBsgNGxeXTlju0HssAQeGsI/+iiEf7SjSSYAIDuI2/wqpmpPt7QJavorJyAWVkWa/udcB9lg5TLx7Qs+t2s8WoTRQAAL4+0dpVkMwPADhA4QYhubwO8tx0vlpNFOZmangLmC4E0Mr4ui2YCvtZ4d6tJAHsHjvcl6LqLXAxAK/NA4A7gqeUN0NbDDBgCAAoQNTG0w37bUYdTIAIQtB9tC9lJlLYNASPDAKAg6PafzfJCxk5Rt3I7lECAieCaB19FKrm5C0xQV3FMAoEoD8FcC72nIQHqIdBDp0H/C3NnbjYNACpeDwjOBxoFQf5Ty8iWDe9LR81aBgBqEjw2cDYQZId25mHdz1IAKLEBvvNMg7NAIQNBjBAAeEAQp3CrPBiYg+p3a+uEAkAOBPyfmgePFcQBhKfkv9zzijk3kKcyORg62/3TWj9v98FzGKpgsGokG9EBfSYiAJA3GJ4DZQZpD7/0gaPronE/PzOKEvEs3WLWFhPA0gG8lXSm80wO7qUMIQcFBYb8L0u53j2hEqDvI5RtHEgHcAwAVBRV0A8MPwVGW+Op8bEjYqXEBpgQtbR1yiRmlU/3GVIrRzSNQ1lWX8lXjvOjzJQpyYXV2w6KcQN5G01H//InlhTkzS6gBx4MSlZVKhfPqtVHgSP/vbPNL0k1ZWpyHVc7Y/qyek6fnXLjstmNrz7yd3LVrNQyrucDN1dvO0jr5TrYwUhdLM9EnAHoohIaixF3//MrsgMgQGJqNksnRN+DNtI1D4zK47WNjS1Hv/69mY0ZRLeZtfyIA2DV8yv6KJVDuB1fdW7e+udSyn3aCfCsvTR535zcGU23r54fPFy55r2Put9et2OBBwCTgsXj8j0KMTOdt3Ju4cM3FuSf7zW+VG1Bs0KKuOeppYdjR16YDqCijSfqv/I3fHRikQcACySN9xDeW79r44iEuJSEiy/C6EfGKgIEjhj9tIvUDIy7fHTz3ncOgqEKowEA/wfh9PpkMENSLAAAAABJRU5ErkJggg==",
-    "version": "4.2.0",
-    "updated": "2026-08-08T09:21:20.111Z",
+    "version": "4.3.0",
+    "updated": "2026-08-13T15:35:32.546Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.2.0/package.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.3.0/package.zip",
     "translations": {
       "zh": {
         "name": "恐龙工具箱",
@@ -957,10 +957,10 @@
     "name": "AI Toolbar",
     "description": "AI assistant in the toolbar: built-in prompts, custom instructions, and user scripts runnable from the AI menu.",
     "category": "Productivity",
-    "version": "4.2.0",
-    "updated": "2026-08-08T09:21:20.111Z",
+    "version": "4.3.0",
+    "updated": "2026-08-13T15:35:32.546Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.2.0/lets-ai-toolbar.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.3.0/lets-ai-toolbar.zip",
     "translations": {
       "zh": {
         "name": "智能工具栏",
@@ -995,10 +995,10 @@
     "name": "Embed View",
     "description": "Embed web pages, HTML content or third-party content in notes, with AI-generated embeds.",
     "category": "Integration",
-    "version": "4.1.1",
-    "updated": "2026-08-08T00:00:00Z",
+    "version": "4.3.0",
+    "updated": "2026-08-13T15:35:32.546Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.1.1/lets-embed-view.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.3.0/lets-embed-view.zip",
     "translations": {
       "zh": {
         "name": "智能嵌入块",


### PR DESCRIPTION
## 🚀 Automated Update

Update orca-hqweay-go, lets-ai-toolbar, lets-embed-view to version **v4.3.0**.

### Downloads
- [orca-hqweay-go](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.3.0/package.zip)
- [lets-ai-toolbar](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.3.0/lets-ai-toolbar.zip)
- [lets-embed-view](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.3.0/lets-embed-view.zip)

### Release Notes


### Minor Changes

- e36ac77: 新增 AI 输出「插入位置」选择（本块下 / 同级后 / 新页面，弹窗内可临时切换，设置页可设默认）；「新页面」以输出首行命名并插入后跳转。新增工具调用可视化：工具执行失败时弹窗内红条提示；设置页「显示工具调用详情」可开启折叠日志。
- 5cf7c37: 嵌入视图（Embed View）：脚本化嵌入中的外链点击（含 `target="_blank"`）现在会直接用系统浏览器打开。修复：在桥接客户端注入链接点击拦截器，统一走 `invokeBackend("shell-open")`，与 webview 弹窗策略解耦；宿主侧保留 `new-window` / `will-navigate` 兜底（bridge 未启用时普通链接仍可打开），同页 `#锚点` 与 `mailto:` 等保持默认行为。另修复嵌入块刷新按钮在部分环境下 `reload()` 返回非 Promise 导致的报错。

