### PR TITLE
Rename Orca Neo plugin id to match internal name

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1028,7 +1028,7 @@
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"128\" height=\"128\" viewBox=\"0 0 128 128\"><rect x=\"8\" y=\"8\" width=\"112\" height=\"112\" rx=\"28\" fill=\"#059669\"/><path d=\"M36 44 L16 64 L36 84\" stroke=\"#ffffff\" stroke-width=\"12\" stroke-linecap=\"round\" stroke-linejoin=\"round\" fill=\"none\"/><path d=\"M92 44 L112 64 L92 84\" stroke=\"#ffffff\" stroke-width=\"12\" stroke-linecap=\"round\" stroke-linejoin=\"round\" fill=\"none\"/><path d=\"M82 30 L46 98\" stroke=\"#ffffff\" stroke-width=\"12\" stroke-linecap=\"round\" fill=\"none\"/></svg>"
   },
   {
-    "id": "lets-orca-neo",
+    "id": "orca-neo",
     "author": "Eon-Wen",
     "name": "Orca Neo",
     "description": "Visual theme adapted from open-source Neo theme of Siyuan Notes for Orca Note, clean reading style with original copyright noted.",


### PR DESCRIPTION
插件 id 从 lets-orca-neo 改为 orca-neo，与包内 package.json 的 name 一致。

原因：虎鲸市场按条目 id 给安装目录命名，旧 id 导致安装后目录名与插件内部名不一致，主题/设置无法生效。改后市场安装目录即为 orca-neo。