### PR TITLE
feat: update Orca SRS to 1.0.10

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -215,10 +215,10 @@
     "description": "A spaced repetition and incremental reading plugin for Orca Note with FSRS scheduling, multiple card types, AI card generation, EPUB/web import, and reading workflows.",
     "category": "Productivity",
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAA40lEQVR4nO3awRHDMAhEUXfgY3pIBWnefeWYVGAvSLBI7Axn+b/Rzeg4X++l56AXCMAuEIBdIAC7oDrgc31XAvxzkSkHALsjJKMAd/oshh8wJX2c4QRMr3cbPICgep/BDAitdxhsgIR6q8EASKs3GVBAcj1ugACUetDQAECsRwy7A+j1jwYBKgPo3YhBAAEE2BVALwYN+96AAAIIsD6gjuGmUIDigAqG+7wGAK7hsa0HgGVAwtr8nU424EnNNjQJBmtMyy1lkMGX0XhTP4Ux/mm9VgFIoefrxRZ7BGCPAOxZHvADvnxNjjg5nvMAAAAASUVORK5CYII=",
-    "version": "1.0.9",
-    "updated": "2026-08-08T09:43:40Z",
+    "version": "1.0.10",
+    "updated": "2026-08-15T06:24:24Z",
     "home": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin",
-    "zip": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.9/orca-srs-1.0.9.zip",
+    "zip": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.10/orca-srs-1.0.10.zip",
     "translations": {
       "zh": {
         "name": "虎鲸标记",


### PR DESCRIPTION
## Orca SRS 1.0.10

更新 orca-srs 插件条目至 **1.0.10**：

- `version`: 1.0.9 → 1.0.10
- `zip`: 指向 `v1.0.10` release 的 `orca-srs-1.0.10.zip`
- `updated`: 2026-08-15

### 1.0.10 变更亮点
- 服务与算法设置：FSRS 权重、最大间隔、图片遮罩模式、关闭通知、IR 首次学习时间
- AI 快捷制卡（自动）与默认 `Alt+C`；单次上限、逐张保留、源块去重
- AI 制卡优先使用当前选区；后台任务可在行尾取消
- 网页导入可跳过 AI 总结，长文按首/中/尾采样
- 选择题统一 `type=choice`；删除卡片会清掉结构和进度
- 章末小测源文完整性门禁；渐进阅读可选紧凑选区工具栏

> 关联发布：https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/tag/v1.0.10