### PR TITLE
Update Orca Neo to 2.0.1

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1071,10 +1071,10 @@
     "name": "Orca Neo",
     "description": "Visual theme adapted from open-source Neo theme of Siyuan Notes for Orca Note, clean reading style with original copyright noted.",
     "category": "Theme",
-    "version": "2.0.0",
-    "updated": "2026-08-13T14:20:00Z",
+    "version": "2.0.1",
+    "updated": "2026-08-16T01:20:34Z",
     "home": "https://github.com/Eon-Wen/Orca-neo",
-    "zip": "https://github.com/Eon-Wen/Orca-neo/releases/download/v2.0.0/orca-neo-v2.0.0.zip",
+    "zip": "https://github.com/Eon-Wen/Orca-neo/releases/download/v2.0.1/orca-neo-v2.0.1.zip",
     "translations": {
       "zh": {
         "name": "Orca Neo主题",


### PR DESCRIPTION
更新 Orca Neo 至 2.0.1。

变更内容：
- version 2.0.0 → 2.0.1
- zip 链接更新为 v2.0.1 Release（已发布，链接可用）
- updated 时间戳更新
- icon_svg 由 128×128 更新为 60×60（符合 ≤60×60 规范）

2.0.1 主要更新（32 项）：
- 新功能：PDF/EPUB 书页背景跟随主题 + 自定义背景图、EPUB 连续垂直滚动、顶栏融合、图标抽屉（含加锁）、页签圆角/自定义图标、白板背景跟随主题、写作统计庆祝动画与实时化、批量包含于浮窗重做（搜索 + 分页 + 多目标）等
- Bug 修复：手动排序刷新后不保持、手动拖拽不灵敏/整屏蓝选（重写为指针自绘）、彩色文档树折叠展开闪帧、缓存页签初始不出现、三点菜单浮窗漂移、列表参考线深入表格/白板等
- 性能优化：全插件一轮保守优化（6 项写前比较/防抖/复用）+ 庆祝动画性能优化

验证：
- home: https://github.com/Eon-Wen/Orca-neo
- zip: https://github.com/Eon-Wen/Orca-neo/releases/download/v2.0.1/orca-neo-v2.0.1.zip（含 package.json / dist / LICENSE / icon.svg）