### PR TITLE
Add Whiteboard plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -210,6 +210,25 @@
   },
   {
     "author": "Samuelxiaozhuofeng",
+    "id": "orca-plugin-whiteboard",
+    "name": "Whiteboard",
+    "description": "A Heptabase-style whiteboard: outline blocks become live-editable cards on an infinite canvas, joined by hand-drawn arrows that can be promoted into real note references.",
+    "category": "Visualization",
+    "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 60 60\" width=\"60\" height=\"60\" role=\"img\" aria-label=\"Whiteboard icon\"><rect width=\"60\" height=\"60\" rx=\"13\" fill=\"#4338CA\"/><path d=\"M15 45V15M30 45V15M45 45V15M15 22h30M15 30h30M15 38h30\" stroke=\"#FFFFFF\" stroke-opacity=\".12\" stroke-width=\"1.4\"/><path d=\"M23 23.5 34.5 35\" stroke=\"#C7D2FE\" stroke-width=\"2.6\" stroke-linecap=\"round\"/><rect x=\"9\" y=\"12\" width=\"21\" height=\"15\" rx=\"3.5\" fill=\"#FFFFFF\"/><rect x=\"13\" y=\"17\" width=\"13\" height=\"2.2\" rx=\"1.1\" fill=\"#A5B4FC\"/><rect x=\"13\" y=\"21\" width=\"9\" height=\"2.2\" rx=\"1.1\" fill=\"#A5B4FC\" fill-opacity=\".65\"/><rect x=\"35\" y=\"10\" width=\"16\" height=\"11\" rx=\"3\" fill=\"#F1F3FF\"/><rect x=\"38\" y=\"14.5\" width=\"10\" height=\"2\" rx=\"1\" fill=\"#A5B4FC\" fill-opacity=\".8\"/><rect x=\"31\" y=\"31\" width=\"21\" height=\"19\" rx=\"3.5\" fill=\"#FFFFFF\"/><rect x=\"35\" y=\"36\" width=\"13\" height=\"2.2\" rx=\"1.1\" fill=\"#A5B4FC\"/><rect x=\"35\" y=\"40\" width=\"13\" height=\"2.2\" rx=\"1.1\" fill=\"#A5B4FC\" fill-opacity=\".65\"/><rect x=\"35\" y=\"44\" width=\"8\" height=\"2.2\" rx=\"1.1\" fill=\"#A5B4FC\" fill-opacity=\".45\"/></svg>",
+    "version": "0.1.0",
+    "updated": "2026-08-16T06:11:09Z",
+    "home": "https://github.com/Samuelxiaozhuofeng/orca-plugin-whiteboard",
+    "zip": "https://github.com/Samuelxiaozhuofeng/orca-plugin-whiteboard/releases/download/v0.1.0/orca-plugin-whiteboard-v0.1.0.zip",
+    "translations": {
+      "zh": {
+        "name": "白板",
+        "description": "Heptabase 风格的白板：大纲块变成无限画布上可就地编辑的卡片，卡片之间用手绘箭头连接，箭头还能转成真正的笔记引用。",
+        "category": "可视化"
+      }
+    }
+  },
+  {
+    "author": "Samuelxiaozhuofeng",
     "id": "orca-srs",
     "name": "Orca SRS",
     "description": "A spaced repetition and incremental reading plugin for Orca Note with FSRS scheduling, multiple card types, AI card generation, EPUB/web import, and reading workflows.",


### PR DESCRIPTION
Adds **Whiteboard** (`orca-plugin-whiteboard`), a Heptabase-style canvas for Orca Note.

Outline blocks become cards you can place freely on an infinite canvas and edit in place, joined by hand-drawn arrows that can be promoted into real note references.

**Checklist against CONTRIBUTING.md**

- [x] `plugins.json` only; format matches the surrounding entries.
- [x] `id` (`orca-plugin-whiteboard`) uses letters and hyphens only, and matches the folder name inside the zip.
- [x] Icon is SVG, 60x60, generated with `node scripts/minify-svg.js`.
- [x] Zip contains `package.json` (with `version`), `dist/`, `LICENSE`, and `icon.png`.
- [x] Inserted next to my other entries, before `orca-srs` in `id` order.
- [x] `home` and `zip` links verified (both return 200; the zip downloads and extracts).
- [x] MIT licensed, with a README covering install and first steps.

Home: https://github.com/Samuelxiaozhuofeng/orca-plugin-whiteboard
Release: https://github.com/Samuelxiaozhuofeng/orca-plugin-whiteboard/releases/tag/v0.1.0
