### PR TITLE
Update Whiteboard to v0.2.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -215,10 +215,10 @@
     "description": "A Heptabase-style whiteboard: outline blocks become live-editable cards on an infinite canvas, joined by hand-drawn arrows that can be promoted into real note references.",
     "category": "Visualization",
     "icon_svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 60 60\" width=\"60\" height=\"60\" role=\"img\" aria-label=\"Whiteboard icon\"><rect width=\"60\" height=\"60\" rx=\"13\" fill=\"#4338CA\"/><path d=\"M15 45V15M30 45V15M45 45V15M15 22h30M15 30h30M15 38h30\" stroke=\"#FFFFFF\" stroke-opacity=\".12\" stroke-width=\"1.4\"/><path d=\"M23 23.5 34.5 35\" stroke=\"#C7D2FE\" stroke-width=\"2.6\" stroke-linecap=\"round\"/><rect x=\"9\" y=\"12\" width=\"21\" height=\"15\" rx=\"3.5\" fill=\"#FFFFFF\"/><rect x=\"13\" y=\"17\" width=\"13\" height=\"2.2\" rx=\"1.1\" fill=\"#A5B4FC\"/><rect x=\"13\" y=\"21\" width=\"9\" height=\"2.2\" rx=\"1.1\" fill=\"#A5B4FC\" fill-opacity=\".65\"/><rect x=\"35\" y=\"10\" width=\"16\" height=\"11\" rx=\"3\" fill=\"#F1F3FF\"/><rect x=\"38\" y=\"14.5\" width=\"10\" height=\"2\" rx=\"1\" fill=\"#A5B4FC\" fill-opacity=\".8\"/><rect x=\"31\" y=\"31\" width=\"21\" height=\"19\" rx=\"3.5\" fill=\"#FFFFFF\"/><rect x=\"35\" y=\"36\" width=\"13\" height=\"2.2\" rx=\"1.1\" fill=\"#A5B4FC\"/><rect x=\"35\" y=\"40\" width=\"13\" height=\"2.2\" rx=\"1.1\" fill=\"#A5B4FC\" fill-opacity=\".65\"/><rect x=\"35\" y=\"44\" width=\"8\" height=\"2.2\" rx=\"1.1\" fill=\"#A5B4FC\" fill-opacity=\".45\"/></svg>",
-    "version": "0.1.0",
-    "updated": "2026-08-16T06:11:09Z",
+    "version": "0.2.0",
+    "updated": "2026-08-17T00:00:00Z",
     "home": "https://github.com/Samuelxiaozhuofeng/orca-plugin-whiteboard",
-    "zip": "https://github.com/Samuelxiaozhuofeng/orca-plugin-whiteboard/releases/download/v0.1.0/orca-plugin-whiteboard-v0.1.0.zip",
+    "zip": "https://github.com/Samuelxiaozhuofeng/orca-plugin-whiteboard/releases/download/v0.2.0/orca-plugin-whiteboard-v0.2.0.zip",
     "translations": {
       "zh": {
         "name": "白板",


### PR DESCRIPTION
Bumps `orca-plugin-whiteboard` to v0.2.0.

Release: https://github.com/Samuelxiaozhuofeng/orca-plugin-whiteboard/releases/tag/v0.2.0

Highlights: media cards (image/video/audio with autoplay guard), relation map, clipboard paste onto the board, media reference jump, plus card editing and selection fixes.

Only the `version`, `updated` and `zip` fields of the existing entry changed. Both `home` and `zip` return 200.