### PR TITLE
Update orca-pizhu to v3.0.0 (Pizhu Toolbox)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -726,18 +726,18 @@
   {
     "author": "kx1356",
     "id": "orca-pizhu",
-    "name": "Pizhu Annotation",
-    "description": "Annotation plugin for Orca Note: wavy-underline marks with numbered badges, hover preview, click-to-edit cards, and a summary panel with jump navigation.",
+    "name": "Pizhu Toolbox",
+    "description": "All-in-one toolbox plugin for Orca Note: annotation (wavy underline + numbered badges + hover preview + edit/delete cards + side summary panel), editor tab bar (click to switch, drag to reorder and split panels, vertical mode, pinned tabs), and trash bin (deleted pages auto-saved, restorable or permanently purged).",
     "category": "Productivity",
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAkMSURBVHhe7Zz7cxtXFcdN+R+gM1D+izQv0jiOpd2VHBJmgCH9gZTCMEzTMgztxE0HbJjCDC3QGX7iNUNc29pdyXrYjuOEpnVKk+ImwbFDaOxYfhQSTIOdKK0f8t7XYc5dSbZWkiVZsjOR9sx8R6PV3nvP/eze565OQ0OZBu3tj1HTd0BE/ccsXT1mGdrT1FR/y8O+K5ahPDJCf6mp/dLSlaNYD6wP7fE3Yv2cda6KQajlS8RU20XM12cZyqfQ1wIQ9QNEfQAxP8jvj5rQb/Qf69HXApapfMKjvj5iqG3C8D7hZLApWzrle3zVVE7SoDYlCxw4BNCjATVVoMGUTBXII6iM/6k6YL1k/aJ+IKYyRQz1ZaE3fd7JpCTDW3kloOwmpnoaznxFZsqCWo4TtSisp7wrzxwCEtT6l7uad5XdtImpvkDD2jLedXiFnIXUg7DeWH8W9i2xoHLcyaigJXXvCyLiI9g/ODOtN8mmHfMBD/sI0YtAhNDXP4t3Hov6LIhgP5CbYb1KdmER/yoJKseRk5OdNKL7dlqGwuxONDeTehc2Z+RDAt4nnewaIOR7nIS0ftnn5UnsKtWce/04sPQJ/VD26Ex05SSOtqROB4yShQMLcjLU1gw8YRx+wtK9s27TLU3IydLVGdGlflECpIbyU4HDtXv3lSQW0oDH/HgXtjUAtD9m6cpfcAbuPNFVYaV4DTbgxgDr0RZ4T32sMqol3uMD3qPNN1jd6ndwIe2OvOWJmZqc1jTgVg52ivW6XNus5Ho57IMGZmhPuwDLVwYgbobi5NAFWJ4yAImhjmEf6DzB1cbKAMTtbRdg+XIBVigXYIVyAVYoF2CFcgFWKBdghXIBVigXYIV6iAAVIMY64feccx6m0n45j2fr4QDs3g8k0AREP7gm/I7Hnec+DK33r8iF3UaACpDAASCde4GeeRbE7FsAiamMxMw5oAPflr/L84o4Xn3l94+e/R6QbvTHeb6t7QGoe4B07ZeAePw0oAkhqBBiSQixnPqkeJzH+4EOPCPPJ4YnN6+tUH7/CPpFzv+Q066nctOktPUAuxuBdO0DcSsGwFfTzk3xu/8YEZO977P4wGX8lN+FmJIn8CSIW1GZTqZ35llNFfLv47EREY9dJL1Hl7jRnJsupa0FiM6Fj4CYjKWv6L/Fg4+G2VDrTWqqy6DvAx7YD/hJg9oSHWq9ib8LIW7L829FgPQc3jqIJfhHDW9uunXaOoAdu4AOtQKwJXQuyeZvjoqLbdep7lkBswmYme0YN72Ax4nuWRGX2q6zhfFRTAdsEejQCSAdu3PLqERl+ldIWwOwYxewC63YFtG5Ob4wPkZDLffB2Ae0yODATAXwPNLTcp8vTIxhegAG7EIVIVbgn1NVBKjZw/6pHcDwynKCzs3w4devsvCRhLy7ctIUFp5Pw19NsOHXrwohZoFb9p14akdqelHu49fq+pdWlQBq9twpfAT45V+nO+JJcv5HU6DvBW5ubjTFdJievv1iXAgRl+PLB79K9Ys4ZywV4tb4h6ocIM7WO3YCCbUALHyYdi7O3nkxDgFsEnnSlCH5JlRgH7B3XspAhPkbQEJ+u9xiq4Ut9m+TALE54NzpKTn5ZO+1Ayz8Ex1LCLZ6lbz90qwcwXLSbU4SIuY3dGJGMAubdAIWbshy5eQX/UB/Mnfk9vlXPsDOL9v9kKEAe/cVgHvj6at6j41Hx3j08Bw3DlbFufXC/DBfFj0yxyZiOLjclwXfGwd24SQQnG6gX2/u3lb/SgcoF/0eYKN/Aj4eArg7knZsmXN+nU1ER5lxIAlB7ODzpK+SMH8sh0304jQHQS5LRz7+u/SL3+rdVv/KA6g3ASTvpR3D5ddNPn12mJ7+1m2mNxEeLG3uVKmwHCyPnj52G8tHP9Af6VjKtsu/kgHi/IgaHuAfDd0Qi3f+ymfPj/DBZ6ZpoBGEiU2iSGdeZWF5stxAI/DBZ6fZ7PkRsXjnklj8zwf4uV3+lQwwLcvwrhLDu2TpHgrBzc2dqi30w9KbqaV7li3du2J/bo9/ZQPEK4mrha26optV2i9cgm2nf2UDdJUtF2CFcgFWKBdghaoTgPYiQC77cKWyofbYuzYlPk6ocYCaDU3u3ChA3/qBvVLZSBNhoL3ftNPisjVrjZ2r2gaI8KLfAHbt9yCW7wLQ5PrFSmFLJkAkZoH97RdAgv4UxDz51zRAvdlerTz4lxNPWcanz9rN2pl/SrULsHs/sMu/cfIAYJbzyMZmfQL03PcLPhuuUYAakI4ngc9dWQPBLFzHA730qr1bU2pzxqTX/wzkzV15yqlVgIEDQAe/C2Jxbo0CXQHx3xH7Wcj/bgCfiAAIvp5TQWPXfmeP0M5yahZg5x5gw685OWRbMoGbXs6jea0OAe4FdulVJ4dNmwuwROPT54B/aMrmvt7qE+D7P8+CsKFxCnyyH/jUIAgceBjJ+rk+AV78WcmDBJ86C+LOsPNwxkoCWFP/lZPPbw4CvzvmZJHfkvYDvkLGRv9YHKBlqK/VVHinzj3AZ845WZRvnAG78ob94qezjCyAunK0pv4vHGgCOnDMiaNsEw9m7Z2ZAm9ArANYY/9YxwrjWwnX/gDi0ztOLiWZuD8J9N1XNnw/cQ1gLcZMQIi4JRX9mhwIytLlN+w7bwN4qEzMBGoojTyszddk1A69Oc/GaRFhn1fk7VQURu1gIW1exo0hhnrOjRtTnjJxY2TcLFNtx0g8buSi0pSJXBTUfiIBrsjYWcqMGzurNMnYWYYyLYL+L2QCkGHAVTd6W3HJsKDIydROZOChYTw8jIvnxg8srLX4gWqv6PR8LgsgGtE9Oy3djWBZSHYES5USU93hZCdNxlANasdpRLMkRCM3k7qUkY6h6lslpvoczlyc7LIsGfA+j1FrMXptvTdn2WxjfhARzSIB9Tknq4JGDO15jJ9cUxsNZSoTRzqiLTKzDHhoGLkbo/oSQ+uv20jmA4dwbty73OnZCdDwGSejkgxH51VDfZmaajydKS6icdKNBdWOVFmvTCx9Q42vGt5WEckz2m7GMFDtqqG28Zi/l5hqAodzWWCtqNcPlqkmeNQfI6by4+VIKsBsEfs/H3jsopdYWkkAAAAASUVORK5CYII=",
-    "version": "0.2.0",
-    "updated": "2026-08-18T08:39:34.327Z",
+    "version": "3.0.0",
+    "updated": "2026-08-18T09:35:18.089Z",
     "home": "https://github.com/kx1356/orca-plugin-pizhu",
-    "zip": "https://github.com/kx1356/orca-plugin-pizhu/releases/download/v0.2.0/orca-pizhu-v0.2.0.zip",
+    "zip": "https://github.com/kx1356/orca-plugin-pizhu/releases/download/v3.0.0/orca-pizhu-v3.0.0.zip",
     "translations": {
       "zh": {
-        "name": "批注",
-        "description": "选中文字添加批注：波浪线 + 角标数字标记，悬停预览，点击编辑或删除，侧边面板汇总当前文档全部批注并可点击跳转。",
+        "name": "批注工具箱",
+        "description": "虎鲸笔记三合一工具箱，均可在设置中开关：①批注：选中文字添加波浪线+角标数字，悬停预览、点击编辑/删除、侧边面板汇总跳转；②编辑器页签栏：点击切换、拖拽排序/分栏、垂直模式、固定页签；③回收站：删除页面自动存入，可恢复或彻底删除。",
         "category": "效率工具"
       }
     }


### PR DESCRIPTION
Update [orca-pizhu](https://github.com/kx1356/orca-plugin-pizhu) index entry to **v3.0.0**.

插件升级为**三合一「批注工具箱」**：批注 + 编辑器页签栏 + 回收站，三功能均可在设置中独立开关。

- 名称改为 **批注工具箱 (Pizhu Toolbox)**
- 合并 orca-tab-bar（页签栏）与 orca-trash-bin（回收站）功能
- 新增：编辑框随内容自适应、角标蓝色、去掉悬停 title
- Release: https://github.com/kx1356/orca-plugin-pizhu/releases/tag/v3.0.0