### PR TITLE
Update hqweay plugins (orca-hqweay-go, lets-time-log, lets-workbench) to v4.8.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -863,10 +863,10 @@
     "description": "Dino Craft - some tools",
     "category": "Productivity",
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAAAXNSR0IArs4c6QAAEPhJREFUeF7tXQtwFdUZPqFFE4LhZnTCQ1OCQmywQCwaIgghYxWxgsFQZphRQLTOODJKtFPUkSYxjo+ZlqDjY6ooj6rpICptKASDTUKIQCoSDQ+NkSTGBMw05CoJpuKQ5tvcc917s49zdvfs3b3ZnWHCvXf3PP7/O99//v/8e04MicJr5b3zVn9U25CPrn1a1+S77vrJpKf7e/8vUkZ/gu92bD8wNwq7bahLMYaecuhDVPHxI+N8eWtyCRQffq17ZhspfvYdcmtOZpUHBEKiBgC35mRWdv73u6xwxQ+LJeR872DEAghffN425EEQFQCgyt9aupaLmzwQRAEDGFU+RcpQB0E0MEBfa1dJcOSrUb4WNSxZUETSJifnvf7K7vVcFBIFN7saABj9k668NOuhRxabUsX+fcfIk2vf8H9a15RoqiAXPuxqABBCQka/GfkPVRZwLQCsGv0UNEOVBVwNgGV335il5OsbZYLkxKV4lEkmrV0lCCbl7955yFdTVe/Dg5V7pDgTaTpxqjnQhkJ8bbQ9djzH1Fk7GmKgDsvon9bNYgao4tc9s20uAkqIO+ACECkYwSZfNp7c/GjehvGyfjkSDK4FwHXXT+7j9fv1QAaX8NuublVvoLWrpEKueIbJZ2E/qxT0s4DEFoSQqv424LNjLlcCACHf48dai0UAQCk6GBj1FWCIzFlphEHxROaOUhBA6VT5jgGBawEwKnFkMYsieIYaqHvLa+WDwsN5a3L7KN0brDM7OXEpnQs4CgSuBYBdDLDhzT8cfu3lnekm2aYyOXFptgyMff3mAJ8jPkH0ACDTSnhYuD/CWLBkQVG+2soiD7tA4U5kAVcCIDDrFjoJhN1fsqCogtXmM4BBiQUiLv+IN4BBcIq3TE2f0PV40R1SsodVFyZ5+/cdk2TydPE9m/75zofLTVJ/SNOSE5fK5e2IuYBrAYBIIA0E7dpzWBL03qr6oMA/rW0k586fD36enpk6CCdzsqZI383/zdXS399mPxZcD4CbaRH1y+uVmwHqGsrnBlZhmbkcVwFg9uIZq9Gz5vrW/GExMRe2fNYWN/HqFKmzE9MDfwOftSTQeJgG6ghprGsm9PP4tEt/TBwzqmbURfG//OF0z2grR3+gPXIA4CtMBiOqg4hWrgdTKPxM55mcznb/tNbP231QNhSNv6nXpShm+uiVqfd72esDE3MKjDtWzZc+P120TO9Rlt/lMQEPAEoSg9IxwvHbhSMu8N1810D+Jh3pLFK28h6wA/6VbawkUzMmkakZE82AwQOAmnLSsydXYqRTpUdK4Xqmg4LBIDOEm4CKQDzASsxylRVRE0BHO+gdI12ieAYbztVDQTfLmQFgYDQRQQDcsvDaFxIS4u8+dqSlF1nM8maeaj/dvPdQ8V2yuIGgXkRoAkIV7+TRziNxzBtgIvSAADdwSvqETfV1TcvpKqJSaBkhaYSeF+bOxIriCp628N5rKwNEm+LDha0FhN07D9Uhb8CXODKFZT0BIEBcorWrJNxs8OpY837bAAAb3+0/m0Wp3tJeOKywcCAgxHyg5riUO8ATuMJz/q7u5o2v7J4gqovCAYBRX73tYDEUf/PKofVGFoDw2YdfkGt/fQVZ99J9hnTIk6VkpAKhAEi+clxXtNh5I8LFM6zzA7Xy5eFpo23Qek4IAFhGvZH8fRECsKJMlr4ACJfEx7F6C8FmuQ4AQ8nW84JHjQ20AOQqAIDyr5qZ6htqtp4HCDSQhGVmltiBfIGKpx7Wey0xAdS985TPKvaBuYGeSYAruObBV5ubTpxyrhdA7f2q51c4LorHYpvZVWb9nQBB+9E28q/dTygWzpKmbrZVphjAyco3Kxi7ngcIWupbyfvlTw6qcs70PKGjHxUaBoCnfOsgogQCBIGSxiQ6MxTsKd865dOS5ObADttP6+VmAE/51is/HATxFwxHbqItaePcAPBcPXEAoJHDztbOb/+zZ+CFU9EXFwAQ5BmTkpTl+fli1fLCA5vI/3p+2Nza0C50KZhrEugpX6zSw0tfPbuAzF48I69620Gh29YwMQAN78LX9y57JICIIZgA+xl+1fzNtPBap2ek+mMIea7w2RV1ZjKHmACA9OX11Y55oVWIBpwYNIJn0PRxMyl68s6QPAJ4CbjwF3kG2AX1mozUQiObXOkCwKN+a/HGCzSwwB8fWxJ8eUWpNTSFDEDg3ehKEwBmlc/bWWtFHR2lUVMg3wpPrWc082hr6VrmNDI9BugTGeNH59ySBSwXut3t1lszkLcNbLCrtJY5jUwVAGZHv9b4o0ui9JUsgEAtV9BJLELX82nf7ExzYzEFtF08u59qMYCwiR9cHKVLJNuYNQhQ/vsllYNeR7MLBBgsH2ypVlw0Cu+baQCIHP3ho0jeeDCBU11NNdCi/XYBl4cFWBNJ1BhAc/SboWUtQUKYTnQ3tUCLNtsFXB4WMAwAkaOfzmi16Niu0cRjEvQAYCdwWViAZ9dTJQYQZvtZBGmXTeUBAIQu31MgkvMXFhbgySQKAYDI0Q+heQDggZ36vTCj2LxC6S0jntGPGgYB4PpFGVmifHMPANYAQM0M8Cp/EAAmXp0iBX5EXW6dA7CYADsnr0pmgB6Gxbv/YJABtOjfzKw/PIIGYWpddgqSFeh6wLXLC5C3V84CUP72t2sMJZAGAYBMn4c33Cs8C0VrNDlxAkiF7rR2A5R1pYfJvvJPTB2BJ58DCJv9s7KAE0c/bbva/CUSox9tAgBKXy7/seV423BWJlO6TwKA6Nl/eMVKlBpJ/5/VxIWDIFLKD2MlvQU9TXxEBADyUeWmfYFEtZsVgOGahFkae8VoU2ljFD220L8ZqvKeHSwBMOm763aebm/uuNiofDwAGJCc0RFroCrNR6R5wEvlpOWzNsMTwRi86HHyy2+KRfr/VnfcK+8nCSAqiGwhuIIf7P6YOzcwxu4JoKc8ayWAeUDFv5+WCpUFg5gnhh4ArNWH7aWFh4V5kkHQ2BgEgG67/yZpI2bvcp8E4JrefktGSNYwDwgcCwCnTLScDgkAYHxiAnl8rXToZdAUKJ1+ptQXCQB2hICdLki3tk9tqxmejCBDMQCtERp/QWyIPOOHx5Gec99L3+G5M9/1ulXeTO3W6j8K6PnBuv7DFfQ3fDNowynhAJBLAh2GkuOHx5LwzqtJDELoOTcgiI6eLibBOvWmSPYfANj7Rk3IPkM8eQFwFwwxAJSBjieNSGRWupYCO3r8rgOCE/qvBADelDBDAEiKTyRJ8dauHrsJBE7pfzgAeEa/5AYaZYBfJYnZuq7Jf9KUjbTLe3BK/8PnADyj3zAAQH0TfGOFmGQ3sICT+k8BsHDeNdL5Aivvnad6+rmiG2iUAQAA1gkfD1KOdDTx3B6xe53SfwDgyJ6jZOSwn+HQa7xzx3UecYyZRFAr7SC8AtC/qEuEaXBC/xEHMLOplCWBIAiCxwWkSqb+cMfZLlN2XxRoWMuNZP8BgFPNHVV1FccMncZhCQCUYgL0OwAjqPCA30+DQt8P6xVy+COr4kTcR2MCLP23IiBkCQBYFoNEUCiPAtBRnObp5S2ESg1yOVrTYHhLOccuBoWDA4kPTs4a5gGzlfcCAN1fdxFffFwVyt2x/QCXKZDyAUS+DmZFZ9FJXFobVOpt24Iy3JiAqic/5AM89cTALmI8y8C0XFcAAJ3Uon4W5bLcoydsJ/4uzwhC+3hBIOUExl8UV+zk7V+1AEBz9fXeK0AZ0XhmIc0JlIOTJxroiqRQNeXRF0ygWL0JYjTMIZQm4n/N+9ugfYOwHlBWWssUEZSSB80Eg+ygRbqrmNwMUOXTkQ+QTExPUZwnsMwh7OiH1XUorQTSOnjyAfCMoRVBqzukVR6lejrapUlh4MRx+hwFAZ0wUuDgczS6j2rZQGCALa+VIzSs6xFIDOCmtDC9yRyULv2rax7wHMJAYidoRdelBgBMBL/t6mY3AV5msFhViQqiyV1A2gNuLwAPGvUERHVMrDqip/RwD4BX+ZCEZAK818PcBwp5HgBsPo6Zx/kBvFvG275BhPtE7cwWw/53NHWQH/3GzwoIMgCdCLIsCjlTHEOvVbD/qWmXbd/51r7neJNA5NIKMoDRecDQE70zegz7n7cm17oTQ7x5gDMUi1boTa7D3T96YsjFlyQw+f6KDOCZAecAQK8lSu8D4hm6RwDPsTEh75GDBabNSSv23hTWU0Fkf1daADIVBwg8XDBp+oTMvvN986IxbBpZlQ2unUYseVdh1aJ/8hoCG0UwbRIR4gaikMtSx/bmrJoX67GAWMgYBYDW6DfCAhQAWDTIxz6z/SxQ5rGAvvL1Jmr6JRDpYEgetlV7Ezi8Lu7FoP4C6CE+0t/ktHHnbrvvpp97LMCiRuP38AKAhf7RGp73A4PbxMm3jr/zT7ll+0sPeXMB47plepIXACynhdCKefIBgvRPH15fXVDxwgOb5kbzUiqThiy+qXZXHcmYnx4slTdLCSbgQMl+8t5O7WN8eZeDQ+gfrVtfXdCnlIVjsTwcV5wVdl2rUwDA6ZP+YNYSLwOgbKSA3XxDOnnokcWqVbGOfhQgvR4up//i6oK5MYRU4EetNCvHac8lDZKnpxkBALr5+sNvkhuypyqCAPa/aO0bm+vrmphO/gAAwABZVH7xo0b4xl6eJPHUpZPGkKqtB2w7F88lOjTdTPqWEwri8QLkFdMUOawHUDYwEwkMyR2bvXjGT4Yqpi/rZGNHjtGGmpaWV4CmBCgQMmelkbM9vYNOD5+SPmHTNRmpWYdqG6TtXJYuv+Efj+ZtwLEt0ts2TNEibztZ56Nww5q3eo982PBsgNGxeXTlju0HssAQeGsI/+iiEf7SjSSYAIDuI2/wqpmpPt7QJavorJyAWVkWa/udcB9lg5TLx7Qs+t2s8WoTRQAAL4+0dpVkMwPADhA4QYhubwO8tx0vlpNFOZmangLmC4E0Mr4ui2YCvtZ4d6tJAHsHjvcl6LqLXAxAK/NA4A7gqeUN0NbDDBgCAAoQNTG0w37bUYdTIAIQtB9tC9lJlLYNASPDAKAg6PafzfJCxk5Rt3I7lECAieCaB19FKrm5C0xQV3FMAoEoD8FcC72nIQHqIdBDp0H/C3NnbjYNACpeDwjOBxoFQf5Ty8iWDe9LR81aBgBqEjw2cDYQZId25mHdz1IAKLEBvvNMg7NAIQNBjBAAeEAQp3CrPBiYg+p3a+uEAkAOBPyfmgePFcQBhKfkv9zzijk3kKcyORg62/3TWj9v98FzGKpgsGokG9EBfSYiAJA3GJ4DZQZpD7/0gaPronE/PzOKEvEs3WLWFhPA0gG8lXSm80wO7qUMIQcFBYb8L0u53j2hEqDvI5RtHEgHcAwAVBRV0A8MPwVGW+Op8bEjYqXEBpgQtbR1yiRmlU/3GVIrRzSNQ1lWX8lXjvOjzJQpyYXV2w6KcQN5G01H//InlhTkzS6gBx4MSlZVKhfPqtVHgSP/vbPNL0k1ZWpyHVc7Y/qyek6fnXLjstmNrz7yd3LVrNQyrucDN1dvO0jr5TrYwUhdLM9EnAHoohIaixF3//MrsgMgQGJqNksnRN+DNtI1D4zK47WNjS1Hv/69mY0ZRLeZtfyIA2DV8yv6KJVDuB1fdW7e+udSyn3aCfCsvTR535zcGU23r54fPFy55r2Put9et2OBBwCTgsXj8j0KMTOdt3Ju4cM3FuSf7zW+VG1Bs0KKuOeppYdjR16YDqCijSfqv/I3fHRikQcACySN9xDeW79r44iEuJSEiy/C6EfGKgIEjhj9tIvUDIy7fHTz3ncOgqEKowEA/wfh9PpkMENSLAAAAABJRU5ErkJggg==",
-    "version": "4.7.0",
-    "updated": "2026-08-19T15:39:11.000Z",
+    "version": "4.8.0",
+    "updated": "2026-08-22T06:42:00.925Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.7.0/package.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.8.0/package.zip",
     "translations": {
       "zh": {
         "name": "恐龙工具箱",
@@ -1071,10 +1071,10 @@
     "name": "Time Log",
     "description": "Aggregate tag time properties (Start/End) into day/week/month timelines and statistics, with AI-generated analysis and SVG charts.",
     "category": "Productivity",
-    "version": "4.7.0",
-    "updated": "2026-08-19T15:39:11.000Z",
+    "version": "4.8.0",
+    "updated": "2026-08-22T06:42:00.925Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.7.0/lets-time-log.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.8.0/lets-time-log.zip",
     "translations": {
       "zh": {
         "name": "时间统计",
@@ -1090,10 +1090,10 @@
     "name": "Workbench",
     "description": "A component-based dashboard: render note blocks natively, random cards, weather widgets, and let AI assemble and arrange the layout.",
     "category": "Productivity",
-    "version": "4.7.0",
-    "updated": "2026-08-19T00:00:00.000Z",
+    "version": "4.8.0",
+    "updated": "2026-08-22T06:42:00.925Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.7.0/lets-workbench.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.8.0/lets-workbench.zip",
     "translations": {
       "zh": {
         "name": "工作台",


### PR DESCRIPTION
## 🚀 Automated Update

Update orca-hqweay-go, lets-time-log, lets-workbench to version **v4.8.0**.

### Downloads
- [orca-hqweay-go](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.8.0/package.zip)
- [lets-time-log](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.8.0/lets-time-log.zip)
- [lets-workbench](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.8.0/lets-workbench.zip)

### Release Notes


### Minor Changes

- 9ffac8b: 时间统计与工作台体验升级：

  - 新增工作台组件「打点热力」：像 GitHub 贡献图一样展示每天的打点密度，格子随日常记录慢慢变深。支持今年、去年、近 12 个月等时间段，鼠标悬停可看某天的时间明细；跨年时按年自动分行。
  - 时间统计页不再显示「年度概览」热力卡——看全年分布用统计页的分布图就够了，热力图搬到了工作台，每天打开就能看到。
  - 时间统计的「目标趋势」改为跟随统计页选择的时间范围：看哪个范围，就显示那个范围内的目标达成情况（此前固定显示近 30 天，与所选范围对不上）。
  - 时间统计右键记录可直接管理：右键时间条或时间点弹出菜单，支持切换到其他标签组（时间自动搬到新组的属性）、移除时间标记（笔记保留）、删除笔记块（连文本一起删，可一键撤销重建）；周视图的时间条现在也能拖上下缘调整起止了。
  - 工作台组件分类重新梳理：新增「时间统计」分类（打点热力移入，另新增「目标进度」组件——展示时间统计里配置的每日 / 每周 / 每月目标达成进度条，需启用时间统计插件）；「块组件」与「笔记卡片」归入新的「笔记」分类，与天气 / 倒计时等「信息类」分开。
  - 工作台空状态新增一键预设布局：「时间看板」（打点热力 + 目标进度）与「信息一览」（天气 + 倒计时 + 笔记卡片），新用户不用从零拼装。
  - 周视图拖拽安排时间段的手感优化：预览改为只覆盖所拖的那一天列内（此前横贯整周），并且使用目标标签组的颜色渲染——预览的样子就是创建后的样子。
  - 工作台「倒数日」组件更名为「日期计数」——它本来就支持倒数和正数两种模式；导出到日记的标签也从 #倒数日 变为 #日期计数（已导出的旧笔记不受影响）。未配置时的指引改为指向卡片右下角的设置入口。
  - 修复时间统计的两处刷新不及时：换组 / 删除记录后，聚焦跳转到对应笔记时不再显示旧内容；右键菜单点选项不再误触发日历打点。
  - 时间统计的记录展示不再带标签尾巴（如「#Task」）：分组看时间条颜色就够了，换组后也不会出现新旧标签混排。
  - 工作台网格分辨率翻倍（24 列 × 13px 行）：拖拽调整大小的吸附步长更细腻，宽面板下不再一拖就跳一大截。已有布局自动换算坐标，外观与尺寸不变。
  - 「时间统计」分类新增四个组件，凑齐完整时间看板：「今日时长」——今天累计投入的大数字 + 各组分时条；「连续记录」——当前连续天数、最长纪录与最近 60 天活跃条；「时段分布」——24 小时柱状图看什么时段投入最多（峰值高亮）；「周规律」——周一到周日平均投入对比。均支持配置时间段与刷新间隔。
  - 打点热力组件的月份标签在窄卡片下自动收起，不再互相叠字。
  - 工作台布局引擎升级（v3）：组件可以摆到网格上的任意位置——拖到哪里就钉在哪里，重叠时其他组件自动下推让位，留白也是合法设计。新增「整理布局」按钮一键消除空隙；已有布局会自动把原排布冻结成固定坐标，外观不变但从此归你所有。
  - 修复工作台调整卡片高度时拖拽步长过大的问题，恢复到与宽度一致的细腻手感。

- 2cf3af2: 工作台全面体验升级：
  - 卡片操作改为右下角悬浮按钮组（悬停出现），不再占用顶部空间、不遮挡内容；编辑、复制、保存到日记、删除统一收进「⋯」菜单。
  - 新增「笔记卡片」组件：放一个块固定展示（便签、封面图、路线图）；拖入带标签的块、查询块或多个块则随机抽取——该标签下的笔记、查询结果，还能图片轮播、回顾灵感。图片块也能随机并随卡片缩放展示。
  - 单块展示时卡片干净纯粹：无来源栏、无「换一张」、无跳转提示；右下角可「刷新」重新拉取内容。

