### PR TITLE
Update hqweay plugins (orca-hqweay-go, lets-ai-toolbar, lets-inject, lets-arc-tabs, lets-embed-view, lets-time-log, lets-workbench) to v4.9.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -863,10 +863,10 @@
     "description": "Dino Craft - some tools",
     "category": "Productivity",
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAAAXNSR0IArs4c6QAAEPhJREFUeF7tXQtwFdUZPqFFE4LhZnTCQ1OCQmywQCwaIgghYxWxgsFQZphRQLTOODJKtFPUkSYxjo+ZlqDjY6ooj6rpICptKASDTUKIQCoSDQ+NkSTGBMw05CoJpuKQ5tvcc917s49zdvfs3b3ZnWHCvXf3PP7/O99//v/8e04MicJr5b3zVn9U25CPrn1a1+S77vrJpKf7e/8vUkZ/gu92bD8wNwq7bahLMYaecuhDVPHxI+N8eWtyCRQffq17ZhspfvYdcmtOZpUHBEKiBgC35mRWdv73u6xwxQ+LJeR872DEAghffN425EEQFQCgyt9aupaLmzwQRAEDGFU+RcpQB0E0MEBfa1dJcOSrUb4WNSxZUETSJifnvf7K7vVcFBIFN7saABj9k668NOuhRxabUsX+fcfIk2vf8H9a15RoqiAXPuxqABBCQka/GfkPVRZwLQCsGv0UNEOVBVwNgGV335il5OsbZYLkxKV4lEkmrV0lCCbl7955yFdTVe/Dg5V7pDgTaTpxqjnQhkJ8bbQ9djzH1Fk7GmKgDsvon9bNYgao4tc9s20uAkqIO+ACECkYwSZfNp7c/GjehvGyfjkSDK4FwHXXT+7j9fv1QAaX8NuublVvoLWrpEKueIbJZ2E/qxT0s4DEFoSQqv424LNjLlcCACHf48dai0UAQCk6GBj1FWCIzFlphEHxROaOUhBA6VT5jgGBawEwKnFkMYsieIYaqHvLa+WDwsN5a3L7KN0brDM7OXEpnQs4CgSuBYBdDLDhzT8cfu3lnekm2aYyOXFptgyMff3mAJ8jPkH0ACDTSnhYuD/CWLBkQVG+2soiD7tA4U5kAVcCIDDrFjoJhN1fsqCogtXmM4BBiQUiLv+IN4BBcIq3TE2f0PV40R1SsodVFyZ5+/cdk2TydPE9m/75zofLTVJ/SNOSE5fK5e2IuYBrAYBIIA0E7dpzWBL03qr6oMA/rW0k586fD36enpk6CCdzsqZI383/zdXS399mPxZcD4CbaRH1y+uVmwHqGsrnBlZhmbkcVwFg9uIZq9Gz5vrW/GExMRe2fNYWN/HqFKmzE9MDfwOftSTQeJgG6ghprGsm9PP4tEt/TBwzqmbURfG//OF0z2grR3+gPXIA4CtMBiOqg4hWrgdTKPxM55mcznb/tNbP231QNhSNv6nXpShm+uiVqfd72esDE3MKjDtWzZc+P120TO9Rlt/lMQEPAEoSg9IxwvHbhSMu8N1810D+Jh3pLFK28h6wA/6VbawkUzMmkakZE82AwQOAmnLSsydXYqRTpUdK4Xqmg4LBIDOEm4CKQDzASsxylRVRE0BHO+gdI12ieAYbztVDQTfLmQFgYDQRQQDcsvDaFxIS4u8+dqSlF1nM8maeaj/dvPdQ8V2yuIGgXkRoAkIV7+TRziNxzBtgIvSAADdwSvqETfV1TcvpKqJSaBkhaYSeF+bOxIriCp628N5rKwNEm+LDha0FhN07D9Uhb8CXODKFZT0BIEBcorWrJNxs8OpY837bAAAb3+0/m0Wp3tJeOKywcCAgxHyg5riUO8ATuMJz/q7u5o2v7J4gqovCAYBRX73tYDEUf/PKofVGFoDw2YdfkGt/fQVZ99J9hnTIk6VkpAKhAEi+clxXtNh5I8LFM6zzA7Xy5eFpo23Qek4IAFhGvZH8fRECsKJMlr4ACJfEx7F6C8FmuQ4AQ8nW84JHjQ20AOQqAIDyr5qZ6htqtp4HCDSQhGVmltiBfIGKpx7Wey0xAdS985TPKvaBuYGeSYAruObBV5ubTpxyrhdA7f2q51c4LorHYpvZVWb9nQBB+9E28q/dTygWzpKmbrZVphjAyco3Kxi7ngcIWupbyfvlTw6qcs70PKGjHxUaBoCnfOsgogQCBIGSxiQ6MxTsKd865dOS5ObADttP6+VmAE/51is/HATxFwxHbqItaePcAPBcPXEAoJHDztbOb/+zZ+CFU9EXFwAQ5BmTkpTl+fli1fLCA5vI/3p+2Nza0C50KZhrEugpX6zSw0tfPbuAzF48I69620Gh29YwMQAN78LX9y57JICIIZgA+xl+1fzNtPBap2ek+mMIea7w2RV1ZjKHmACA9OX11Y55oVWIBpwYNIJn0PRxMyl68s6QPAJ4CbjwF3kG2AX1mozUQiObXOkCwKN+a/HGCzSwwB8fWxJ8eUWpNTSFDEDg3ehKEwBmlc/bWWtFHR2lUVMg3wpPrWc082hr6VrmNDI9BugTGeNH59ySBSwXut3t1lszkLcNbLCrtJY5jUwVAGZHv9b4o0ui9JUsgEAtV9BJLELX82nf7ExzYzEFtF08u59qMYCwiR9cHKVLJNuYNQhQ/vsllYNeR7MLBBgsH2ypVlw0Cu+baQCIHP3ho0jeeDCBU11NNdCi/XYBl4cFWBNJ1BhAc/SboWUtQUKYTnQ3tUCLNtsFXB4WMAwAkaOfzmi16Niu0cRjEvQAYCdwWViAZ9dTJQYQZvtZBGmXTeUBAIQu31MgkvMXFhbgySQKAYDI0Q+heQDggZ36vTCj2LxC6S0jntGPGgYB4PpFGVmifHMPANYAQM0M8Cp/EAAmXp0iBX5EXW6dA7CYADsnr0pmgB6Gxbv/YJABtOjfzKw/PIIGYWpddgqSFeh6wLXLC5C3V84CUP72t2sMJZAGAYBMn4c33Cs8C0VrNDlxAkiF7rR2A5R1pYfJvvJPTB2BJ58DCJv9s7KAE0c/bbva/CUSox9tAgBKXy7/seV423BWJlO6TwKA6Nl/eMVKlBpJ/5/VxIWDIFLKD2MlvQU9TXxEBADyUeWmfYFEtZsVgOGahFkae8VoU2ljFD220L8ZqvKeHSwBMOm763aebm/uuNiofDwAGJCc0RFroCrNR6R5wEvlpOWzNsMTwRi86HHyy2+KRfr/VnfcK+8nCSAqiGwhuIIf7P6YOzcwxu4JoKc8ayWAeUDFv5+WCpUFg5gnhh4ArNWH7aWFh4V5kkHQ2BgEgG67/yZpI2bvcp8E4JrefktGSNYwDwgcCwCnTLScDgkAYHxiAnl8rXToZdAUKJ1+ptQXCQB2hICdLki3tk9tqxmejCBDMQCtERp/QWyIPOOHx5Gec99L3+G5M9/1ulXeTO3W6j8K6PnBuv7DFfQ3fDNowynhAJBLAh2GkuOHx5LwzqtJDELoOTcgiI6eLibBOvWmSPYfANj7Rk3IPkM8eQFwFwwxAJSBjieNSGRWupYCO3r8rgOCE/qvBADelDBDAEiKTyRJ8dauHrsJBE7pfzgAeEa/5AYaZYBfJYnZuq7Jf9KUjbTLe3BK/8PnADyj3zAAQH0TfGOFmGQ3sICT+k8BsHDeNdL5Aivvnad6+rmiG2iUAQAA1gkfD1KOdDTx3B6xe53SfwDgyJ6jZOSwn+HQa7xzx3UecYyZRFAr7SC8AtC/qEuEaXBC/xEHMLOplCWBIAiCxwWkSqb+cMfZLlN2XxRoWMuNZP8BgFPNHVV1FccMncZhCQCUYgL0OwAjqPCA30+DQt8P6xVy+COr4kTcR2MCLP23IiBkCQBYFoNEUCiPAtBRnObp5S2ESg1yOVrTYHhLOccuBoWDA4kPTs4a5gGzlfcCAN1fdxFffFwVyt2x/QCXKZDyAUS+DmZFZ9FJXFobVOpt24Iy3JiAqic/5AM89cTALmI8y8C0XFcAAJ3Uon4W5bLcoydsJ/4uzwhC+3hBIOUExl8UV+zk7V+1AEBz9fXeK0AZ0XhmIc0JlIOTJxroiqRQNeXRF0ygWL0JYjTMIZQm4n/N+9ugfYOwHlBWWssUEZSSB80Eg+ygRbqrmNwMUOXTkQ+QTExPUZwnsMwh7OiH1XUorQTSOnjyAfCMoRVBqzukVR6lejrapUlh4MRx+hwFAZ0wUuDgczS6j2rZQGCALa+VIzSs6xFIDOCmtDC9yRyULv2rax7wHMJAYidoRdelBgBMBL/t6mY3AV5msFhViQqiyV1A2gNuLwAPGvUERHVMrDqip/RwD4BX+ZCEZAK818PcBwp5HgBsPo6Zx/kBvFvG275BhPtE7cwWw/53NHWQH/3GzwoIMgCdCLIsCjlTHEOvVbD/qWmXbd/51r7neJNA5NIKMoDRecDQE70zegz7n7cm17oTQ7x5gDMUi1boTa7D3T96YsjFlyQw+f6KDOCZAecAQK8lSu8D4hm6RwDPsTEh75GDBabNSSv23hTWU0Fkf1daADIVBwg8XDBp+oTMvvN986IxbBpZlQ2unUYseVdh1aJ/8hoCG0UwbRIR4gaikMtSx/bmrJoX67GAWMgYBYDW6DfCAhQAWDTIxz6z/SxQ5rGAvvL1Jmr6JRDpYEgetlV7Ezi8Lu7FoP4C6CE+0t/ktHHnbrvvpp97LMCiRuP38AKAhf7RGp73A4PbxMm3jr/zT7ll+0sPeXMB47plepIXACynhdCKefIBgvRPH15fXVDxwgOb5kbzUiqThiy+qXZXHcmYnx4slTdLCSbgQMl+8t5O7WN8eZeDQ+gfrVtfXdCnlIVjsTwcV5wVdl2rUwDA6ZP+YNYSLwOgbKSA3XxDOnnokcWqVbGOfhQgvR4up//i6oK5MYRU4EetNCvHac8lDZKnpxkBALr5+sNvkhuypyqCAPa/aO0bm+vrmphO/gAAwABZVH7xo0b4xl6eJPHUpZPGkKqtB2w7F88lOjTdTPqWEwri8QLkFdMUOawHUDYwEwkMyR2bvXjGT4Yqpi/rZGNHjtGGmpaWV4CmBCgQMmelkbM9vYNOD5+SPmHTNRmpWYdqG6TtXJYuv+Efj+ZtwLEt0ts2TNEibztZ56Nww5q3eo982PBsgNGxeXTlju0HssAQeGsI/+iiEf7SjSSYAIDuI2/wqpmpPt7QJavorJyAWVkWa/udcB9lg5TLx7Qs+t2s8WoTRQAAL4+0dpVkMwPADhA4QYhubwO8tx0vlpNFOZmangLmC4E0Mr4ui2YCvtZ4d6tJAHsHjvcl6LqLXAxAK/NA4A7gqeUN0NbDDBgCAAoQNTG0w37bUYdTIAIQtB9tC9lJlLYNASPDAKAg6PafzfJCxk5Rt3I7lECAieCaB19FKrm5C0xQV3FMAoEoD8FcC72nIQHqIdBDp0H/C3NnbjYNACpeDwjOBxoFQf5Ty8iWDe9LR81aBgBqEjw2cDYQZId25mHdz1IAKLEBvvNMg7NAIQNBjBAAeEAQp3CrPBiYg+p3a+uEAkAOBPyfmgePFcQBhKfkv9zzijk3kKcyORg62/3TWj9v98FzGKpgsGokG9EBfSYiAJA3GJ4DZQZpD7/0gaPronE/PzOKEvEs3WLWFhPA0gG8lXSm80wO7qUMIQcFBYb8L0u53j2hEqDvI5RtHEgHcAwAVBRV0A8MPwVGW+Op8bEjYqXEBpgQtbR1yiRmlU/3GVIrRzSNQ1lWX8lXjvOjzJQpyYXV2w6KcQN5G01H//InlhTkzS6gBx4MSlZVKhfPqtVHgSP/vbPNL0k1ZWpyHVc7Y/qyek6fnXLjstmNrz7yd3LVrNQyrucDN1dvO0jr5TrYwUhdLM9EnAHoohIaixF3//MrsgMgQGJqNksnRN+DNtI1D4zK47WNjS1Hv/69mY0ZRLeZtfyIA2DV8yv6KJVDuB1fdW7e+udSyn3aCfCsvTR535zcGU23r54fPFy55r2Put9et2OBBwCTgsXj8j0KMTOdt3Ju4cM3FuSf7zW+VG1Bs0KKuOeppYdjR16YDqCijSfqv/I3fHRikQcACySN9xDeW79r44iEuJSEiy/C6EfGKgIEjhj9tIvUDIy7fHTz3ncOgqEKowEA/wfh9PpkMENSLAAAAABJRU5ErkJggg==",
-    "version": "4.8.0",
-    "updated": "2026-08-22T06:42:00.925Z",
+    "version": "4.9.0",
+    "updated": "2026-08-23T18:43:42.051Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.8.0/package.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/package.zip",
     "translations": {
       "zh": {
         "name": "恐龙工具箱",
@@ -995,10 +995,10 @@
     "name": "AI Toolbar",
     "description": "AI assistant in the toolbar: built-in prompts, custom instructions, and user scripts runnable from the AI menu.",
     "category": "Productivity",
-    "version": "4.3.0",
-    "updated": "2026-08-13T15:35:32.546Z",
+    "version": "4.9.0",
+    "updated": "2026-08-23T18:43:42.051Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.3.0/lets-ai-toolbar.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-ai-toolbar.zip",
     "translations": {
       "zh": {
         "name": "智能工具栏",
@@ -1014,10 +1014,10 @@
     "name": "Arc Tabs",
     "description": "Arc-browser style sidebar for managing your notes and tabs, with recents and block drag-and-drop.",
     "category": "Note Management",
-    "version": "4.1.1",
-    "updated": "2026-08-08T00:00:00Z",
+    "version": "4.9.0",
+    "updated": "2026-08-23T18:43:42.051Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.1.1/lets-arc-tabs.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-arc-tabs.zip",
     "translations": {
       "zh": {
         "name": "Arc 风格标签页",
@@ -1033,10 +1033,10 @@
     "name": "Embed View",
     "description": "Embed web pages, HTML content or third-party content in notes, with AI-generated embeds.",
     "category": "Integration",
-    "version": "4.3.0",
-    "updated": "2026-08-13T15:35:32.546Z",
+    "version": "4.9.0",
+    "updated": "2026-08-23T18:43:42.051Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.3.0/lets-embed-view.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-embed-view.zip",
     "translations": {
       "zh": {
         "name": "智能嵌入块",
@@ -1052,10 +1052,10 @@
     "name": "User Scripts",
     "description": "Inject styles and scripts from code blocks; generate user scripts with AI; bind toolbar, block menu, sidebar entries and widgets.",
     "category": "Productivity",
-    "version": "4.7.0",
-    "updated": "2026-08-19T15:39:11.000Z",
+    "version": "4.9.0",
+    "updated": "2026-08-23T18:43:42.051Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.7.0/lets-inject.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-inject.zip",
     "translations": {
       "zh": {
         "name": "用户脚本",
@@ -1071,10 +1071,10 @@
     "name": "Time Log",
     "description": "Aggregate tag time properties (Start/End) into day/week/month timelines and statistics, with AI-generated analysis and SVG charts.",
     "category": "Productivity",
-    "version": "4.8.0",
-    "updated": "2026-08-22T06:42:00.925Z",
+    "version": "4.9.0",
+    "updated": "2026-08-23T18:43:42.051Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.8.0/lets-time-log.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-time-log.zip",
     "translations": {
       "zh": {
         "name": "时间统计",
@@ -1090,10 +1090,10 @@
     "name": "Workbench",
     "description": "A component-based dashboard: render note blocks natively, random cards, weather widgets, and let AI assemble and arrange the layout.",
     "category": "Productivity",
-    "version": "4.8.0",
-    "updated": "2026-08-22T06:42:00.925Z",
+    "version": "4.9.0",
+    "updated": "2026-08-23T18:43:42.051Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.8.0/lets-workbench.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-workbench.zip",
     "translations": {
       "zh": {
         "name": "工作台",


### PR DESCRIPTION
## 🚀 Automated Update

Update orca-hqweay-go, lets-ai-toolbar, lets-inject, lets-arc-tabs, lets-embed-view, lets-time-log, lets-workbench to version **v4.9.0**.

### Downloads
- [orca-hqweay-go](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/package.zip)
- [lets-ai-toolbar](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-ai-toolbar.zip)
- [lets-inject](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-inject.zip)
- [lets-arc-tabs](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-arc-tabs.zip)
- [lets-embed-view](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-embed-view.zip)
- [lets-time-log](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-time-log.zip)
- [lets-workbench](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-workbench.zip)

### Release Notes


### Minor Changes

- b272d5d: inject 模板库新增「最近访问」挂件：

  - 自动记录最近打开过的块——页面和日记都显示标题/日期，点击即跳回；重复访问自动置顶，跳回目标永远在最上面。
  - 切换日记也能稳定记录：以面板日期为权威反查对应日记块，不会因加载时序漏记或显示成「无标题」。
  - 默认保留 30 条，可在脚本顶部 MAX 修改；已默认勾选 sidebar，插入后在 #脚本 标签属性勾选 autoRun 生效。

  lets-inject 平台能力升级，$inject 运行时新增三组 API：

  - $inject.storage——按脚本块隔离的持久化 KV 存储（随 repo 隔离、跨重启保留），脚本不再各自手搓 localStorage。
  - 脚本配置面板——脚本用 registerSettings 声明参数表单（文本 / 数字 / 开关 / 下拉），设置页自动生成输入项，保存后立即生效并持久化；分享的脚本不用改源码、填参数即可用。
  - 定时任务——schedule.every(分钟) 与 schedule.daily("HH:MM") 定时执行，时刻对齐跨天自动补排；卸载脚本自动取消。
  - 配置弹窗——openConfig(anchorEl) 打开锚定表单，设置页区块已移除。
  - 侧边栏注册表支持声明式组头动作（actions）：render 模式组的返回行最右可渲染图标按钮，「最近访问」的 ⚙ 配置入口即由此声明。

  模板插入的代码块折叠标题与显示名现在都会带上版本号（如「番茄钟 v2」），方便区分同名模板块的新旧。

- 686fa65: 工作台布局升级为「激活即跟踪」模式（类似 Obsidian 工作区）：

  - 加载某个布局后即进入该布局：之后的组件增删、拖拽、调参都会**自动保存**回这个布局，不用再手动重新保存同名快照。
  - 菜单里当前布局带 ✓ 标识；不想自动保存时点「退出布局」回到自由模式。
  - 布局支持行内重命名和一键创建副本；删除当前布局会自动回到自由模式。
  - 通过脚本切换布局（window.workbench.applyLayout）后同样进入跟踪模式，切换后的微调也会保留。

### Patch Changes

- ec8e169: 全面适配夜间模式与若干修复：

  - 全部子插件设置页、弹窗、面板适配明暗主题：此前多处使用了虎鲸笔记不存在的样式变量，界面在夜间模式下显示为刺眼的浅色硬编码，现已全部改用主题变量，跟随系统明暗自动切换。涉及设置页、AI 脚本弹窗、工作台工具栏、本地图谱、CSV 导入、块导航、块流、复习面板等。
  - 修复侧边栏挂件「组头动作按钮串台」的问题：从一个挂件切到另一个挂件后，右上角动作按钮仍停留在上一个挂件（点 ⚙ 打开的是别的脚本的配置），现在始终对应当前挂件。
  - 修复重启软件后恢复布局、组件叠成单列的问题：保存的布局坐标在重新加载时被错误地二次缩放，导致并排组件全部变全宽并被推挤成一行。
  - 嵌入视图的 HTML 现在会自动继承当前主题配色：嵌入内容运行在独立文档中，之前使用主题变量的嵌入块实际取不到颜色；现在打开时注入主题色快照，AI 生成的嵌入卡片在夜间模式下也正常显示。
  - AI 生成脚本 / 嵌入卡片时会严格使用真实存在的主题变量，不再编造变量名导致颜色失效。

- 97a9d07: 修复与微调：

  - 修复工作台恢复布局后组件重叠的问题：早期迁移与保存的布局快照可能带有重叠坐标，现在加载 / 恢复时会自动下推让位。
  - 修复工作台组件无法调整高度的问题：较高的卡片拉高后会被悄悄钳回；上限已提升至 48 行（约 1200px）。
  - 笔记卡片的「文本卡片」渲染方式更名为「轻量卡片」：该模式下图片块直接以图片渲染（自适应缩放、对齐设置生效），「文本对齐」配置同步更名为「对齐（仅轻量卡片）」。

