### PR TITLE
feat: update Orca SRS to 1.0.11

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -234,10 +234,10 @@
     "description": "A spaced repetition and incremental reading plugin for Orca Note with FSRS scheduling, multiple card types, AI card generation, EPUB/web import, and reading workflows.",
     "category": "Productivity",
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAA40lEQVR4nO3awRHDMAhEUXfgY3pIBWnefeWYVGAvSLBI7Axn+b/Rzeg4X++l56AXCMAuEIBdIAC7oDrgc31XAvxzkSkHALsjJKMAd/oshh8wJX2c4QRMr3cbPICgep/BDAitdxhsgIR6q8EASKs3GVBAcj1ugACUetDQAECsRwy7A+j1jwYBKgPo3YhBAAEE2BVALwYN+96AAAIIsD6gjuGmUIDigAqG+7wGAK7hsa0HgGVAwtr8nU424EnNNjQJBmtMyy1lkMGX0XhTP4Ux/mm9VgFIoefrxRZ7BGCPAOxZHvADvnxNjjg5nvMAAAAASUVORK5CYII=",
-    "version": "1.0.10",
-    "updated": "2026-08-15T06:24:24Z",
+    "version": "1.0.11",
+    "updated": "2026-08-27T05:20:12Z",
     "home": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin",
-    "zip": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.10/orca-srs-1.0.10.zip",
+    "zip": "https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/download/v1.0.11/orca-srs-1.0.11.zip",
     "translations": {
       "zh": {
         "name": "虎鲸标记",


### PR DESCRIPTION
## Orca SRS 1.0.11

更新 orca-srs 插件条目至 **1.0.11**：

- `version`: 1.0.10 → 1.0.11
- `zip`: 指向 `v1.0.11` release 的 `orca-srs-1.0.11.zip`
- `updated`: 2026-08-27

### 1.0.11 变更亮点
- 复习面板新增「显示上级路径」按钮：复习嵌套子块卡片时，点击可在题目上方展开该卡片的祖先面包屑，再点收起，切换卡片自动收起；六种卡型（普通/填空/选择/列表/方向/图片遮挡）复习界面均已支持

> 关联发布：https://github.com/Samuelxiaozhuofeng/orca-srs-plugin/releases/tag/v1.0.11