### PR TITLE
Update hqweay plugins (orca-hqweay-go, lets-ai-toolbar, lets-inject, lets-arc-tabs, lets-embed-view, lets-time-log, lets-workbench) to v4.10.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -867,11 +867,13 @@
     "updated": "2026-08-28T16:17:17.293Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
     "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/package.zip",
+    "donate": "https://raw.githubusercontent.com/hqweay/picbed/refs/heads/master/img/donate.jpeg",
     "translations": {
       "zh": {
         "name": "恐龙工具箱",
         "description": "一些快捷工具合集",
-        "category": "效率工具"
+        "category": "效率工具",
+        "donate": "https://raw.githubusercontent.com/hqweay/picbed/refs/heads/master/img/donate.jpeg"
       }
     }
   },

--- a/plugins.json
+++ b/plugins.json
@@ -863,10 +863,10 @@
     "description": "Dino Craft - some tools",
     "category": "Productivity",
     "icon_png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAAAXNSR0IArs4c6QAAEPhJREFUeF7tXQtwFdUZPqFFE4LhZnTCQ1OCQmywQCwaIgghYxWxgsFQZphRQLTOODJKtFPUkSYxjo+ZlqDjY6ooj6rpICptKASDTUKIQCoSDQ+NkSTGBMw05CoJpuKQ5tvcc917s49zdvfs3b3ZnWHCvXf3PP7/O99//v/8e04MicJr5b3zVn9U25CPrn1a1+S77vrJpKf7e/8vUkZ/gu92bD8wNwq7bahLMYaecuhDVPHxI+N8eWtyCRQffq17ZhspfvYdcmtOZpUHBEKiBgC35mRWdv73u6xwxQ+LJeR872DEAghffN425EEQFQCgyt9aupaLmzwQRAEDGFU+RcpQB0E0MEBfa1dJcOSrUb4WNSxZUETSJifnvf7K7vVcFBIFN7saABj9k668NOuhRxabUsX+fcfIk2vf8H9a15RoqiAXPuxqABBCQka/GfkPVRZwLQCsGv0UNEOVBVwNgGV335il5OsbZYLkxKV4lEkmrV0lCCbl7955yFdTVe/Dg5V7pDgTaTpxqjnQhkJ8bbQ9djzH1Fk7GmKgDsvon9bNYgao4tc9s20uAkqIO+ACECkYwSZfNp7c/GjehvGyfjkSDK4FwHXXT+7j9fv1QAaX8NuublVvoLWrpEKueIbJZ2E/qxT0s4DEFoSQqv424LNjLlcCACHf48dai0UAQCk6GBj1FWCIzFlphEHxROaOUhBA6VT5jgGBawEwKnFkMYsieIYaqHvLa+WDwsN5a3L7KN0brDM7OXEpnQs4CgSuBYBdDLDhzT8cfu3lnekm2aYyOXFptgyMff3mAJ8jPkH0ACDTSnhYuD/CWLBkQVG+2soiD7tA4U5kAVcCIDDrFjoJhN1fsqCogtXmM4BBiQUiLv+IN4BBcIq3TE2f0PV40R1SsodVFyZ5+/cdk2TydPE9m/75zofLTVJ/SNOSE5fK5e2IuYBrAYBIIA0E7dpzWBL03qr6oMA/rW0k586fD36enpk6CCdzsqZI383/zdXS399mPxZcD4CbaRH1y+uVmwHqGsrnBlZhmbkcVwFg9uIZq9Gz5vrW/GExMRe2fNYWN/HqFKmzE9MDfwOftSTQeJgG6ghprGsm9PP4tEt/TBwzqmbURfG//OF0z2grR3+gPXIA4CtMBiOqg4hWrgdTKPxM55mcznb/tNbP231QNhSNv6nXpShm+uiVqfd72esDE3MKjDtWzZc+P120TO9Rlt/lMQEPAEoSg9IxwvHbhSMu8N1810D+Jh3pLFK28h6wA/6VbawkUzMmkakZE82AwQOAmnLSsydXYqRTpUdK4Xqmg4LBIDOEm4CKQDzASsxylRVRE0BHO+gdI12ieAYbztVDQTfLmQFgYDQRQQDcsvDaFxIS4u8+dqSlF1nM8maeaj/dvPdQ8V2yuIGgXkRoAkIV7+TRziNxzBtgIvSAADdwSvqETfV1TcvpKqJSaBkhaYSeF+bOxIriCp628N5rKwNEm+LDha0FhN07D9Uhb8CXODKFZT0BIEBcorWrJNxs8OpY837bAAAb3+0/m0Wp3tJeOKywcCAgxHyg5riUO8ATuMJz/q7u5o2v7J4gqovCAYBRX73tYDEUf/PKofVGFoDw2YdfkGt/fQVZ99J9hnTIk6VkpAKhAEi+clxXtNh5I8LFM6zzA7Xy5eFpo23Qek4IAFhGvZH8fRECsKJMlr4ACJfEx7F6C8FmuQ4AQ8nW84JHjQ20AOQqAIDyr5qZ6htqtp4HCDSQhGVmltiBfIGKpx7Wey0xAdS985TPKvaBuYGeSYAruObBV5ubTpxyrhdA7f2q51c4LorHYpvZVWb9nQBB+9E28q/dTygWzpKmbrZVphjAyco3Kxi7ngcIWupbyfvlTw6qcs70PKGjHxUaBoCnfOsgogQCBIGSxiQ6MxTsKd865dOS5ObADttP6+VmAE/51is/HATxFwxHbqItaePcAPBcPXEAoJHDztbOb/+zZ+CFU9EXFwAQ5BmTkpTl+fli1fLCA5vI/3p+2Nza0C50KZhrEugpX6zSw0tfPbuAzF48I69620Gh29YwMQAN78LX9y57JICIIZgA+xl+1fzNtPBap2ek+mMIea7w2RV1ZjKHmACA9OX11Y55oVWIBpwYNIJn0PRxMyl68s6QPAJ4CbjwF3kG2AX1mozUQiObXOkCwKN+a/HGCzSwwB8fWxJ8eUWpNTSFDEDg3ehKEwBmlc/bWWtFHR2lUVMg3wpPrWc082hr6VrmNDI9BugTGeNH59ySBSwXut3t1lszkLcNbLCrtJY5jUwVAGZHv9b4o0ui9JUsgEAtV9BJLELX82nf7ExzYzEFtF08u59qMYCwiR9cHKVLJNuYNQhQ/vsllYNeR7MLBBgsH2ypVlw0Cu+baQCIHP3ho0jeeDCBU11NNdCi/XYBl4cFWBNJ1BhAc/SboWUtQUKYTnQ3tUCLNtsFXB4WMAwAkaOfzmi16Niu0cRjEvQAYCdwWViAZ9dTJQYQZvtZBGmXTeUBAIQu31MgkvMXFhbgySQKAYDI0Q+heQDggZ36vTCj2LxC6S0jntGPGgYB4PpFGVmifHMPANYAQM0M8Cp/EAAmXp0iBX5EXW6dA7CYADsnr0pmgB6Gxbv/YJABtOjfzKw/PIIGYWpddgqSFeh6wLXLC5C3V84CUP72t2sMJZAGAYBMn4c33Cs8C0VrNDlxAkiF7rR2A5R1pYfJvvJPTB2BJ58DCJv9s7KAE0c/bbva/CUSox9tAgBKXy7/seV423BWJlO6TwKA6Nl/eMVKlBpJ/5/VxIWDIFLKD2MlvQU9TXxEBADyUeWmfYFEtZsVgOGahFkae8VoU2ljFD220L8ZqvKeHSwBMOm763aebm/uuNiofDwAGJCc0RFroCrNR6R5wEvlpOWzNsMTwRi86HHyy2+KRfr/VnfcK+8nCSAqiGwhuIIf7P6YOzcwxu4JoKc8ayWAeUDFv5+WCpUFg5gnhh4ArNWH7aWFh4V5kkHQ2BgEgG67/yZpI2bvcp8E4JrefktGSNYwDwgcCwCnTLScDgkAYHxiAnl8rXToZdAUKJ1+ptQXCQB2hICdLki3tk9tqxmejCBDMQCtERp/QWyIPOOHx5Gec99L3+G5M9/1ulXeTO3W6j8K6PnBuv7DFfQ3fDNowynhAJBLAh2GkuOHx5LwzqtJDELoOTcgiI6eLibBOvWmSPYfANj7Rk3IPkM8eQFwFwwxAJSBjieNSGRWupYCO3r8rgOCE/qvBADelDBDAEiKTyRJ8dauHrsJBE7pfzgAeEa/5AYaZYBfJYnZuq7Jf9KUjbTLe3BK/8PnADyj3zAAQH0TfGOFmGQ3sICT+k8BsHDeNdL5Aivvnad6+rmiG2iUAQAA1gkfD1KOdDTx3B6xe53SfwDgyJ6jZOSwn+HQa7xzx3UecYyZRFAr7SC8AtC/qEuEaXBC/xEHMLOplCWBIAiCxwWkSqb+cMfZLlN2XxRoWMuNZP8BgFPNHVV1FccMncZhCQCUYgL0OwAjqPCA30+DQt8P6xVy+COr4kTcR2MCLP23IiBkCQBYFoNEUCiPAtBRnObp5S2ESg1yOVrTYHhLOccuBoWDA4kPTs4a5gGzlfcCAN1fdxFffFwVyt2x/QCXKZDyAUS+DmZFZ9FJXFobVOpt24Iy3JiAqic/5AM89cTALmI8y8C0XFcAAJ3Uon4W5bLcoydsJ/4uzwhC+3hBIOUExl8UV+zk7V+1AEBz9fXeK0AZ0XhmIc0JlIOTJxroiqRQNeXRF0ygWL0JYjTMIZQm4n/N+9ugfYOwHlBWWssUEZSSB80Eg+ygRbqrmNwMUOXTkQ+QTExPUZwnsMwh7OiH1XUorQTSOnjyAfCMoRVBqzukVR6lejrapUlh4MRx+hwFAZ0wUuDgczS6j2rZQGCALa+VIzSs6xFIDOCmtDC9yRyULv2rax7wHMJAYidoRdelBgBMBL/t6mY3AV5msFhViQqiyV1A2gNuLwAPGvUERHVMrDqip/RwD4BX+ZCEZAK818PcBwp5HgBsPo6Zx/kBvFvG275BhPtE7cwWw/53NHWQH/3GzwoIMgCdCLIsCjlTHEOvVbD/qWmXbd/51r7neJNA5NIKMoDRecDQE70zegz7n7cm17oTQ7x5gDMUi1boTa7D3T96YsjFlyQw+f6KDOCZAecAQK8lSu8D4hm6RwDPsTEh75GDBabNSSv23hTWU0Fkf1daADIVBwg8XDBp+oTMvvN986IxbBpZlQ2unUYseVdh1aJ/8hoCG0UwbRIR4gaikMtSx/bmrJoX67GAWMgYBYDW6DfCAhQAWDTIxz6z/SxQ5rGAvvL1Jmr6JRDpYEgetlV7Ezi8Lu7FoP4C6CE+0t/ktHHnbrvvpp97LMCiRuP38AKAhf7RGp73A4PbxMm3jr/zT7ll+0sPeXMB47plepIXACynhdCKefIBgvRPH15fXVDxwgOb5kbzUiqThiy+qXZXHcmYnx4slTdLCSbgQMl+8t5O7WN8eZeDQ+gfrVtfXdCnlIVjsTwcV5wVdl2rUwDA6ZP+YNYSLwOgbKSA3XxDOnnokcWqVbGOfhQgvR4up//i6oK5MYRU4EetNCvHac8lDZKnpxkBALr5+sNvkhuypyqCAPa/aO0bm+vrmphO/gAAwABZVH7xo0b4xl6eJPHUpZPGkKqtB2w7F88lOjTdTPqWEwri8QLkFdMUOawHUDYwEwkMyR2bvXjGT4Yqpi/rZGNHjtGGmpaWV4CmBCgQMmelkbM9vYNOD5+SPmHTNRmpWYdqG6TtXJYuv+Efj+ZtwLEt0ts2TNEibztZ56Nww5q3eo982PBsgNGxeXTlju0HssAQeGsI/+iiEf7SjSSYAIDuI2/wqpmpPt7QJavorJyAWVkWa/udcB9lg5TLx7Qs+t2s8WoTRQAAL4+0dpVkMwPADhA4QYhubwO8tx0vlpNFOZmangLmC4E0Mr4ui2YCvtZ4d6tJAHsHjvcl6LqLXAxAK/NA4A7gqeUN0NbDDBgCAAoQNTG0w37bUYdTIAIQtB9tC9lJlLYNASPDAKAg6PafzfJCxk5Rt3I7lECAieCaB19FKrm5C0xQV3FMAoEoD8FcC72nIQHqIdBDp0H/C3NnbjYNACpeDwjOBxoFQf5Ty8iWDe9LR81aBgBqEjw2cDYQZId25mHdz1IAKLEBvvNMg7NAIQNBjBAAeEAQp3CrPBiYg+p3a+uEAkAOBPyfmgePFcQBhKfkv9zzijk3kKcyORg62/3TWj9v98FzGKpgsGokG9EBfSYiAJA3GJ4DZQZpD7/0gaPronE/PzOKEvEs3WLWFhPA0gG8lXSm80wO7qUMIQcFBYb8L0u53j2hEqDvI5RtHEgHcAwAVBRV0A8MPwVGW+Op8bEjYqXEBpgQtbR1yiRmlU/3GVIrRzSNQ1lWX8lXjvOjzJQpyYXV2w6KcQN5G01H//InlhTkzS6gBx4MSlZVKhfPqtVHgSP/vbPNL0k1ZWpyHVc7Y/qyek6fnXLjstmNrz7yd3LVrNQyrucDN1dvO0jr5TrYwUhdLM9EnAHoohIaixF3//MrsgMgQGJqNksnRN+DNtI1D4zK47WNjS1Hv/69mY0ZRLeZtfyIA2DV8yv6KJVDuB1fdW7e+udSyn3aCfCsvTR535zcGU23r54fPFy55r2Put9et2OBBwCTgsXj8j0KMTOdt3Ju4cM3FuSf7zW+VG1Bs0KKuOeppYdjR16YDqCijSfqv/I3fHRikQcACySN9xDeW79r44iEuJSEiy/C6EfGKgIEjhj9tIvUDIy7fHTz3ncOgqEKowEA/wfh9PpkMENSLAAAAABJRU5ErkJggg==",
-    "version": "4.9.0",
-    "updated": "2026-08-23T18:43:42.051Z",
+    "version": "4.10.0",
+    "updated": "2026-08-28T16:17:17.293Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/package.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/package.zip",
     "translations": {
       "zh": {
         "name": "恐龙工具箱",
@@ -995,10 +995,10 @@
     "name": "AI Toolbar",
     "description": "AI assistant in the toolbar: built-in prompts, custom instructions, and user scripts runnable from the AI menu.",
     "category": "Productivity",
-    "version": "4.9.0",
-    "updated": "2026-08-23T18:43:42.051Z",
+    "version": "4.10.0",
+    "updated": "2026-08-28T16:17:17.293Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-ai-toolbar.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-ai-toolbar.zip",
     "translations": {
       "zh": {
         "name": "智能工具栏",
@@ -1014,10 +1014,10 @@
     "name": "Arc Tabs",
     "description": "Arc-browser style sidebar for managing your notes and tabs, with recents and block drag-and-drop.",
     "category": "Note Management",
-    "version": "4.9.0",
-    "updated": "2026-08-23T18:43:42.051Z",
+    "version": "4.10.0",
+    "updated": "2026-08-28T16:17:17.293Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-arc-tabs.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-arc-tabs.zip",
     "translations": {
       "zh": {
         "name": "Arc 风格标签页",
@@ -1033,10 +1033,10 @@
     "name": "Embed View",
     "description": "Embed web pages, HTML content or third-party content in notes, with AI-generated embeds.",
     "category": "Integration",
-    "version": "4.9.0",
-    "updated": "2026-08-23T18:43:42.051Z",
+    "version": "4.10.0",
+    "updated": "2026-08-28T16:17:17.293Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-embed-view.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-embed-view.zip",
     "translations": {
       "zh": {
         "name": "智能嵌入块",
@@ -1052,10 +1052,10 @@
     "name": "User Scripts",
     "description": "Inject styles and scripts from code blocks; generate user scripts with AI; bind toolbar, block menu, sidebar entries and widgets.",
     "category": "Productivity",
-    "version": "4.9.0",
-    "updated": "2026-08-23T18:43:42.051Z",
+    "version": "4.10.0",
+    "updated": "2026-08-28T16:17:17.293Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-inject.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-inject.zip",
     "translations": {
       "zh": {
         "name": "用户脚本",
@@ -1071,10 +1071,10 @@
     "name": "Time Log",
     "description": "Aggregate tag time properties (Start/End) into day/week/month timelines and statistics, with AI-generated analysis and SVG charts.",
     "category": "Productivity",
-    "version": "4.9.0",
-    "updated": "2026-08-23T18:43:42.051Z",
+    "version": "4.10.0",
+    "updated": "2026-08-28T16:17:17.293Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-time-log.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-time-log.zip",
     "translations": {
       "zh": {
         "name": "时间统计",
@@ -1090,10 +1090,10 @@
     "name": "Workbench",
     "description": "A component-based dashboard: render note blocks natively, random cards, weather widgets, and let AI assemble and arrange the layout.",
     "category": "Productivity",
-    "version": "4.9.0",
-    "updated": "2026-08-23T18:43:42.051Z",
+    "version": "4.10.0",
+    "updated": "2026-08-28T16:17:17.293Z",
     "home": "https://github.com/hqweay/orca-hqweay-go",
-    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.9.0/lets-workbench.zip",
+    "zip": "https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-workbench.zip",
     "translations": {
       "zh": {
         "name": "工作台",


### PR DESCRIPTION
## 🚀 Automated Update

Update orca-hqweay-go, lets-ai-toolbar, lets-inject, lets-arc-tabs, lets-embed-view, lets-time-log, lets-workbench to version **v4.10.0**.

### Downloads
- [orca-hqweay-go](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/package.zip)
- [lets-ai-toolbar](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-ai-toolbar.zip)
- [lets-inject](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-inject.zip)
- [lets-arc-tabs](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-arc-tabs.zip)
- [lets-embed-view](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-embed-view.zip)
- [lets-time-log](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-time-log.zip)
- [lets-workbench](https://github.com/hqweay/orca-hqweay-go/releases/download/v4.10.0/lets-workbench.zip)

### Release Notes


### Minor Changes

- 8c6ad5a: 嵌入卡片支持「卡片配置」：

  - 卡片脚本可声明配置项（如轮播间隔、图片源），嵌入块头部 ⚙ / 工作台卡片 ⋯ 菜单出现通用配置表单。
  - 配置值存在块属性里、跟笔记走（导出 / 同步不丢）；改完配置卡片立即重跑生效。

- 38b885c: 嵌入视图新增「/卡片市场」斜杠命令，并把三个插入命令的交互统一：

  - 编辑器里输 `/卡片市场` 即可从卡片市场选卡（随机壁纸、图片轮播等），一键插入为嵌入块。
  - 插入契约统一：光标所在块为空白时原地转换，有内容时插入到下方，绝不覆盖已有内容。「创建嵌入块」同步遵循此契约——在段落上触发不再隐藏原文。
  - 卡片市场弹窗改为共享组件（自带样式），工作台侧行为不变。

- 5b41c31: 嵌入卡片平台 API：`$embed` 升级为卡片 OS。

  - **`$embed.config`**：defineConfig 声明的配置值由宿主直接注入只读快照，卡片不用再手写块属性读取；用户改配置后卡片自动重跑（工作台与嵌入视图一致）。
  - **`$embed.onVisible(cb)` / `$embed.onHidden(cb)`**：可见性生命周期，卡片可见才跑、不可见自动停（webview 回退为加载时一次性触发）。
  - **`$embed.saveAsset(data)` / `$embed.insertBlock(repr)`**：一键把二进制存进仓库 assets、往卡片下插入子块（saveAsset 仅沙箱路径，需 `typeof` 守卫）。
  - AI 生成文档与骨架同步改用新 API；lint 会纠正手写配置协议的生成结果。

  随机壁纸卡片（v8）已迁移到新 API，脚本净减 26 行。

- 8c6ad5a: 嵌入视图新增「沙箱渲染」（默认开启）：

  - 脚本化嵌入在主渲染进程的 Shadow DOM 里执行，无需独立 webview 进程，打开更快、内存更省。
  - 主题变量随宿主自动继承，不再需要注入。
  - 含外部 `<script src>` 的嵌入自动回退 webview；个别不兼容的旧嵌入可在设置里关闭沙箱。

- 869c4ea: inject 模板库新增「AI 属性填充」：

  - 给标签添加一个 @ 开头的文本属性（如 @AI），在标签 schema 的默认值里写提示词（支持 `[属性名]` 引用同标签其它属性的当前值）。
  - 点击块的标签打开属性面板后，@ 属性行的首图标变为 ✨，点击即由 AI 按提示词生成并填充该属性；输入框里手写的提示词优先于默认值。
  - 需配置「AI 对话设置」，插入模板后勾选脚本的 autoRun 生效。

- 00dbcab: inject 新增「脚本更新」：脚本迭代不再依赖插件发版。

  - 设置页新增「脚本更新」区：一键从远端脚本注册表拉取索引，自动比对已插入脚本的版本，列出可更新项。
  - 更新即一键替换已插入脚本的代码并同步版本徽标；实例通过代码头部的模板标记识别，改名也不怕认错。
  - 脚本注册表独立维护于 hqweay/orca-scripts 仓库，地址可在设置页自定义。
  - 市场支持 CSS 脚本；索引按用途分类（质感 / 挂件 / 工具 / 布局 / AI）分 tab 浏览。
  - 内置模板库精简为精选集，其余模板改由市场分发。

- e839503: 样式清除新增「标题转普通块」：把页面里的标题一键转回普通文本块。
  - 支持任意级别标题，也包含自动标题（自动层级）。
  - 在「样式清除」的 headbar 菜单里点「标题转普通块」即可，转换后会提示已转换的数量。
- c51c69d: 时间统计：刷新机制重写，性能与实时性双提升。

  - 新增变更订阅（orca.state 事件流 → 定点更新缓存）：笔记里任何会影响统计的编辑（改文本、调整时间、打标签、删除、撤销）约 0.4 秒内反映到时间线与统计，此前外部编辑最长要等 60 秒轮询。
  - 打点 / 调整 / 删除后的 1.2 秒全量重取已移除，写入即时生效。
  - 常态开销大幅下降：不再每分钟全量拉取全部时间记录，全量只剩面板冷启动一次与设置变更。

- 8c6ad5a: 工作台：

  - 「添加组件」接入卡片市场：分类浏览（数据 / 图片），选卡即装进网格。
  - 支持配置的卡片可在 ⋯ 菜单直接编辑参数。
  - 拖放防误触：往工作台面板拖文件不再误触编辑器的「拖放文件以插入」；卡片自身的文件拖放（如图片轮播）不受影响。

- 6a2948f: 工作台：块组件里的嵌入卡片现在实时跟随块变化。

  - 在笔记里修改卡片的 HTML、标题或配置，工作台 cell 约 0.4 秒内同步，不再冻结到手动刷新。
  - 块变更订阅下沉为共享基建（时间统计与工作台共用一次订阅），命中拉取改为批量接口，单次 IPC 取回全部变更块。

- 9119513: 工作台的嵌入卡片渲染与嵌入视图对齐：两者共用同一套渲染管线。

  - 工作台里拖入的 HTML 嵌入卡片，现在与嵌入视图行为一致：加载失败会显示具体错误、外链统一用系统浏览器打开。
  - 嵌入卡片内脚本能拿到所在块的真实 id（此前为空）。

- 4753b54: 工作台布局支持「全屏启动」：

  - 每个布局可标记为全屏启动（布局菜单行内的最大化图标，点亮即生效）：激活该布局时自动进入全屏——效果与点击顶部全屏按钮一致，其他面板收起；切到未标记的布局则自动退出全屏并还原面板。
  - 从侧栏重新打开工作台时，若激活中的布局带此标记，也会自动进入全屏。
  - 脚本 API 升级：`window.workbench.applyLayout("布局名", { wide: true })` 可在切换布局的同时指定本次的全屏态（一次性，不写入布局设置）。
  - 全屏按钮的图标与文案现在实时反映真实状态——无论改动来自按钮、布局切换还是脚本。

### Patch Changes

- 0db572b: 嵌入块修复：「允许操作笔记库」关闭后，部分嵌入卡片仍能读取和修改笔记库，现在会真正生效——关闭即完全禁止嵌入访问笔记数据。
- 08af900: 时间统计 AI tab 的保存结果列表支持折叠：

  - 每条结果卡片默认收起，只显示类型、镜头、月份、时间等元数据；点击卡片头部展开查看完整内容（分析文本 / 图表），可同时展开多条对比。
  - 刚生成的结果自动展开，无需再找再点。
  - 展开状态仅本次会话内保留，重新进入时恢复全部折叠。

