### PR TITLE
bump orca-pizhu to v3.5.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -748,10 +748,10 @@
     "name": "Pizhu Toolbox",
     "description": "All-in-one toolbox plugin for Orca Note: annotations (wavy underline + numbered badges + hover preview + edit/delete cards + one-click top-bar popup summary), Fluent 2 editor tab bar (click to switch, drag to reorder/split, vertical mode, pinned tabs), and trash bin (deleted pages auto-saved, restorable or permanently purged). All features toggleable in settings.",
     "category": "Productivity",
-    "version": "3.4.2",
-    "updated": "2026-09-10T02:45:07Z",
+    "version": "3.5.0",
+    "updated": "2026-09-11T08:56:21Z",
     "home": "https://github.com/kx1356/orca-plugin-pizhu",
-    "zip": "https://github.com/kx1356/orca-plugin-pizhu/releases/download/v3.4.2/orca-pizhu-v3.4.2.zip",
+    "zip": "https://github.com/kx1356/orca-plugin-pizhu/releases/download/v3.5.0/orca-pizhu-v3.5.0.zip",
     "translations": {
       "zh": {
         "name": "批注工具箱",


### PR DESCRIPTION
Update **orca-pizhu** to v3.5.0.

- Release: https://github.com/kx1356/orca-plugin-pizhu/releases/tag/v3.5.0
- Zip: https://github.com/kx1356/orca-plugin-pizhu/releases/download/v3.5.0/orca-pizhu-v3.5.0.zip

Highlights since 3.4.2: per-annotation colors (+ color/line-style settings), cross-block annotations, undoable add/edit/delete, annotation popup search/sort/keyboard-navigation/copy-as-Markdown, trash bin search + multi-select batch restore/delete, full zh/en i18n, and dead-code cleanup.