### PR TITLE
bump orca-pizhu to v3.6.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -746,16 +746,16 @@
     "author": "kx1356",
     "id": "orca-pizhu",
     "name": "Pizhu Toolbox",
-    "description": "All-in-one toolbox plugin for Orca Note: annotations (wavy underline + numbered badges + hover preview + edit/delete cards + one-click top-bar popup summary), Fluent 2 editor tab bar (click to switch, drag to reorder/split, vertical mode, pinned tabs), and trash bin (deleted pages auto-saved, restorable or permanently purged). All features toggleable in settings.",
+    "description": "All-in-one toolbox plugin for Orca Note: annotations (wavy underline + numbered badges + hover preview + edit/delete cards + colors + cross-block + search/keyboard navigation + one-click top-bar popup + generated summary page), Fluent 2 editor tab bar (click to switch, drag to reorder/split, vertical mode, pinned tabs), and trash bin (deleted pages auto-saved, restorable or permanently purged, search + batch actions). All features toggleable in settings.",
     "category": "Productivity",
-    "version": "3.5.0",
-    "updated": "2026-09-11T08:56:21Z",
+    "version": "3.6.0",
+    "updated": "2026-09-11T09:26:57Z",
     "home": "https://github.com/kx1356/orca-plugin-pizhu",
-    "zip": "https://github.com/kx1356/orca-plugin-pizhu/releases/download/v3.5.0/orca-pizhu-v3.5.0.zip",
+    "zip": "https://github.com/kx1356/orca-plugin-pizhu/releases/download/v3.6.0/orca-pizhu-v3.6.0.zip",
     "translations": {
       "zh": {
         "name": "批注工具箱",
-        "description": "虎鲸笔记三合一工具箱，均可在设置中开关（Fluent 2 设计）：①批注：选中文字添加波浪线 + 角标序号，悬停预览、点击编辑/删除，顶栏「批注」下拉卡一键汇总并跳转；②编辑器页签栏：点击切换、拖拽排序/分栏、垂直模式、固定页签；③回收站：删除页面自动存入，可恢复或彻底删除。",
+        "description": "虎鲸笔记三合一工具箱，均可在设置中开关（Fluent 2 设计）：①批注：选中文字添加波浪线 + 角标序号，悬停预览、点击编辑/删除，支持跨块、颜色、搜索与键盘导航，顶栏「批注」下拉卡一键汇总/复制，并可生成 Orca 原生批注汇总页；②编辑器页签栏：点击切换、拖拽排序/分栏、垂直模式、固定页签；③回收站：删除页面自动存入，可恢复、彻底删除、搜索与批量操作。",
         "category": "效率工具"
       }
     },


### PR DESCRIPTION
Update **orca-pizhu** to v3.6.0.

- Release: https://github.com/kx1356/orca-plugin-pizhu/releases/tag/v3.6.0
- Zip: https://github.com/kx1356/orca-plugin-pizhu/releases/download/v3.6.0/orca-pizhu-v3.6.0.zip

Since 3.4.2: per-annotation colors (+ color/line-style settings), cross-block annotations, undoable add/edit/delete, popup search/sort/keyboard navigation/copy-as-Markdown, an Orca-native generated annotation summary page, trash bin search + multi-select batch actions, and full zh/en i18n.